### PR TITLE
PLT-3464 - Display Ada amounts in a more readable way in Marlowe Explorer

### DIFF
--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -17,7 +17,7 @@ import Text.Blaze.Html5 ( Html, Markup, ToMarkup(toMarkup), (!), a, b, code, p, 
 import Text.Blaze.Html5.Attributes ( href, style )
 import Text.Printf (printf)
 
-import Explorer.Web.Util ( tr, th, td, table, baseDoc, mkNavLink, stringToHtml )
+import Explorer.Web.Util ( tr, th, td, table, baseDoc, mkNavLink, stringToHtml, prettyPrintAmount )
 import Language.Marlowe.Pretty ( pretty )
 import qualified Language.Marlowe.Runtime.Types.ContractJSON as CJ
 import Language.Marlowe.Runtime.Types.ContractJSON
@@ -219,10 +219,6 @@ renderParty :: Party -> String
 renderParty (Address ad) = printf "Address: %s" $ unpack ad
 renderParty (Role ro) = printf "Role: %s" $ unpack ro
 
-renderToken :: Token -> String
-renderToken (Token "" "") = "ADA (Lovelace)"
-renderToken (Token currSymbol tokenName) = printf "%s (%s)" currSymbol tokenName
-
 renderMAccounts :: Map (Party, Token) Money -> Html
 renderMAccounts mapAccounts = table $ do
   tr $ do
@@ -230,11 +226,16 @@ renderMAccounts mapAccounts = table $ do
     th $ b "currency (token name)"
     th $ b "amount"
   let mkRow ((party, token), money) =
+        let (tokenString, moneyString) = renderToken token money in
         tr $ do
           td . string . renderParty $ party
-          td . string . renderToken $ token
-          td . string . show $ money
+          td . string $ tokenString
+          td . string $ moneyString
   mapM_ mkRow $ Map.toList mapAccounts
+
+renderToken :: Token -> Money -> (String, String)
+renderToken (Token "" "") money = ("ADA", prettyPrintAmount 6 money)
+renderToken (Token currSymbol tokenName) money = (printf "%s (%s)" currSymbol tokenName, prettyPrintAmount 0 money)
 
 renderBoundValues :: Map ValueId Integer -> String
 renderBoundValues mapBoundValues = case Map.toList mapBoundValues of

--- a/src/Explorer/Web/Util.hs
+++ b/src/Explorer/Web/Util.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Explorer.Web.Util
-  ( baseDoc, generateLink, mkNavLink, stringToHtml, table, td, th, tr )
+  ( baseDoc, generateLink, mkNavLink, prettyPrintAmount, stringToHtml, table, td, th, tr )
   where
 
 import Data.Bifunctor (Bifunctor (bimap))
@@ -55,3 +55,19 @@ stringToHtml str = mconcat $ map processLine $ lines str
 
 generateLink :: String -> [(String, String)] -> String
 generateLink path params = path ++ unpack (renderSimpleQuery True (map (bimap pack pack) params))
+
+
+prettyPrintAmount :: Int -> Integer -> String
+prettyPrintAmount decimalPositions amount = if decimals /= [] then integers ++ '.':decimals else integers
+  where (revDecimals, revIntegers) = splitAt decimalPositions $ reverse (show amount)
+        decimals = reverse $ padWithZeroesTill decimalPositions revDecimals
+        integers = reverse $ addThousandSeparators $ padWithZeroesTill 1 revIntegers
+
+addThousandSeparators :: String -> String
+addThousandSeparators (c1:c2:c3:t@(_:_)) = c1:c2:c3:',':addThousandSeparators t
+addThousandSeparators r = r
+
+padWithZeroesTill :: Int -> String -> String
+padWithZeroesTill x [] = replicate x '0'
+padWithZeroesTill x l@(h:t) | x <= 0 = l
+                            | otherwise = h:padWithZeroesTill (x - 1) t


### PR DESCRIPTION
- Fixed the decoding of MerkleizedCase hashes (it is now stored as the ByteString of the Hash, and displayed as base16)
- Added thousand separators to amounts
- Display ADA with decimals as opposed to as Lovelace (divide by 1,000,000)