### PR TITLE
PLT-4148 - Transaction detail view for Marlowe Explorer

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -39,6 +39,9 @@ cradle:
     - path: "./src/Language/Marlowe/Runtime/Types/LazyFeed.hs"
       component: "marlowe-explorer:lib"
 
+    - path: "./src/Language/Marlowe/Runtime/Types/TransactionJSON.hs"
+      component: "marlowe-explorer:lib"
+
     - path: "./src/Language/Marlowe/Runtime/Types/TransactionsJSON.hs"
       component: "marlowe-explorer:lib"
 

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -36,6 +36,7 @@ library
       Language.Marlowe.Runtime.Types.ContractsJSON
       Language.Marlowe.Runtime.Types.IndexedSeq
       Language.Marlowe.Runtime.Types.LazyFeed
+      Language.Marlowe.Runtime.Types.TransactionJSON
       Language.Marlowe.Runtime.Types.TransactionsJSON
       Language.Marlowe.Semantics.Types
       Lib
@@ -55,6 +56,7 @@ library
     , containers
     , errors
     , extra
+    , ghc
     , http-client
     , http-conduit
     , http-types
@@ -88,6 +90,7 @@ executable marlowe-explorer-exe
     , containers
     , errors
     , extra
+    , ghc
     , http-client
     , http-conduit
     , http-types
@@ -120,6 +123,7 @@ test-suite marlowe-explorer-test
     , containers
     , errors
     , extra
+    , ghc
     , hspec
     , hspec-wai
     , http-client

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -53,6 +53,7 @@ library
     , blaze-markup
     , bytestring
     , containers
+    , errors
     , extra
     , http-client
     , http-conduit
@@ -85,6 +86,7 @@ executable marlowe-explorer-exe
     , blaze-markup
     , bytestring
     , containers
+    , errors
     , extra
     , http-client
     , http-conduit
@@ -116,6 +118,7 @@ test-suite marlowe-explorer-test
     , blaze-markup
     , bytestring
     , containers
+    , errors
     , extra
     , hspec
     , hspec-wai

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -53,6 +53,7 @@ library
     , blaze-markup
     , bytestring
     , containers
+    , extra
     , http-client
     , http-conduit
     , http-types
@@ -84,6 +85,7 @@ executable marlowe-explorer-exe
     , blaze-markup
     , bytestring
     , containers
+    , extra
     , http-client
     , http-conduit
     , http-types
@@ -114,6 +116,7 @@ test-suite marlowe-explorer-test
     , blaze-markup
     , bytestring
     , containers
+    , extra
     , hspec
     , hspec-wai
     , http-client

--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
 - containers
 - errors
 - extra
+- ghc
 - http-client
 - http-conduit
 - http-types

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - blaze-markup
 - bytestring
 - containers
+- extra
 - http-client
 - http-conduit
 - http-types

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - blaze-markup
 - bytestring
 - containers
+- errors
 - extra
 - http-client
 - http-conduit

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
   f = { mkDerivation, base, blaze-html, gtk, lib, process
       , temporary, zlib, aeson, servant-server, wai, warp, haskell-language-server
       , hspec, hspec-wai, servant-blaze, http-client, wl-pprint
-      , http-conduit, http-types
+      , http-conduit, http-types, errors
       }:
       mkDerivation {
         pname = "marlowe-explorer";
@@ -16,7 +16,7 @@ let
         executableHaskellDepends = [
           base blaze-html gtk process temporary zlib
           aeson servant-server wai warp
-          haskell-language-server 
+          haskell-language-server errors
           hspec hspec-wai servant-blaze
           http-client wl-pprint http-conduit http-types
         ];

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -182,9 +182,7 @@ data CTVRs = CTVRs String [CTVR]
 
 
 renderCTVRs :: [CTVR] -> Html
-
 renderCTVRs [] = p ! style "color: red" $ string "There are no transactions"
-
 renderCTVRs ctvrs = table $ do
     tr $ do
       th $ b "Transaction ID"

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -11,13 +11,11 @@ import Data.List (intercalate)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text (unpack)
-import Data.Time (formatTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Data.Time.Format (defaultTimeLocale)
 import Text.Blaze.Html5 ( Html, Markup, ToMarkup(toMarkup), (!), a, b, code, p, string, toHtml )
 import Text.Blaze.Html5.Attributes ( href, style )
 import Text.Printf (printf)
-import Explorer.Web.Util ( tr, th, td, table, baseDoc, mkNavLink, stringToHtml, prettyPrintAmount )
+import Explorer.Web.Util ( tr, th, td, table, baseDoc, mkNavLink, stringToHtml, prettyPrintAmount, makeLocalDateTime )
 import Language.Marlowe.Pretty ( pretty )
 import qualified Language.Marlowe.Runtime.Types.ContractJSON as CJ
 import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJ
@@ -231,9 +229,9 @@ renderChoices mapChoices = case Map.keys mapChoices of
     . map (\(ChoiceId choiceName party) -> show party <> ": " <> unpack choiceName)
     $ listChoiceIds
 
-renderTime :: POSIXTime -> String
+renderTime :: POSIXTime -> Html
 renderTime =
-  formatTime defaultTimeLocale "%s [%A, %d %B %Y %T %Z]"  -- ..and format it.
+  makeLocalDateTime  -- ..and format it.
   . posixSecondsToUTCTime  -- ..convert to UTCTime for the formatting function..
   . realToFrac . (/ (1000 :: Double)) . fromIntegral  -- ..convert from millis to epoch seconds..
   . getPOSIXTime  -- Get the Integer out of our custom type..
@@ -248,7 +246,7 @@ renderMState (Just st) = table $ do
   tr $ do td $ b "choices"
           td . string . renderChoices . choices $ st
   tr $ do td $ b "minTime"
-          td . string . renderTime . minTime $ st
+          td . renderTime . minTime $ st
 
 renderMContract :: Maybe Contract -> Html
 renderMContract Nothing = string "Contract closed"

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -5,38 +5,50 @@ module Explorer.Web.ContractView
   (ContractView(..), contractView)
   where
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, forM)
 import Control.Monad.Extra (whenMaybe)
 import Data.List (intercalate)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text (unpack)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Text.Blaze.Html5 ( Html, Markup, ToMarkup(toMarkup), (!), a, b, code, p, string, toHtml )
+import GHC.Utils.Misc (split)
+import Text.Blaze.Html5 ( Html, Markup, ToMarkup(toMarkup), (!), a, b, code, p, string, ToValue (toValue) )
 import Text.Blaze.Html5.Attributes ( href, style )
 import Text.Printf (printf)
-import Explorer.Web.Util ( tr, th, td, table, baseDoc, mkNavLink, stringToHtml, prettyPrintAmount, makeLocalDateTime )
+import Explorer.Web.Util ( tr, th, td, table, baseDoc, stringToHtml, prettyPrintAmount, makeLocalDateTime, generateLink )
 import Language.Marlowe.Pretty ( pretty )
 import qualified Language.Marlowe.Runtime.Types.ContractJSON as CJ
-import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJ
-import Language.Marlowe.Semantics.Types (ChoiceId(..), Contract, Money, POSIXTime(..), Party(..),
+import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJs
+import qualified Language.Marlowe.Runtime.Types.TransactionJSON as TJ
+import Language.Marlowe.Semantics.Types (ChoiceId(..), Contract, Input(..), Money, POSIXTime(..), Party(..),
                                          State(..), Token(..), ValueId(..))
 import Opts (Options, mkUrlPrefix)
 import Control.Monad.Except (runExceptT, ExceptT (ExceptT))
+import Prelude hiding (div)
+import Data.Time (UTCTime)
 
-contractView :: Options -> Maybe String -> Maybe String -> IO ContractView
-contractView opts mTab (Just cid) = do
+contractView :: Options -> Maybe String -> Maybe String -> Maybe String -> IO ContractView
+contractView opts mTab (Just cid) mTxId = do
   let urlPrefix = mkUrlPrefix opts
       tab = parseTab mTab
   r <- runExceptT (do cjson <- ExceptT $ CJ.getContractJSON urlPrefix cid
                       let link = CJ.transactions $ CJ.links cjson
-                      txjson <- whenMaybe (tab == CTxView)
-                                        $ ExceptT $ TJ.getContractTransactions urlPrefix link
-                      return $ extractInfo tab cjson txjson)
+                      txsjson <- whenMaybe (tab == CTxView)
+                                           $ ExceptT $ TJs.getContractTransactions urlPrefix link
+                      let mTxId2 = getIfInContract mTxId txsjson
+                      txjson <- forM mTxId2 (ExceptT . TJ.getTransaction urlPrefix link)
+                      return $ extractInfo tab cjson txsjson txjson)
   return $ either ContractViewError id r
+contractView opts Nothing cid txId = contractView opts (Just "state") cid txId
+contractView _opts _tab Nothing _txId = return $ ContractViewError "Need to specify a contractId"
 
-contractView opts Nothing cid = contractView opts (Just "state") cid
-contractView _opts _tab Nothing = return $ ContractViewError "Need to specify a contractId"
+
+getIfInContract :: Maybe String -> Maybe TJs.Transactions -> Maybe String
+getIfInContract mTxId@(Just txId) (Just (TJs.Transactions { TJs.transactions = txList })) =
+  if any ((== txId) . TJs.transactionId . TJs.resource) txList then mTxId else Nothing
+getIfInContract _ _ = Nothing
+
 
 parseTab :: Maybe String -> ContractViews
 parseTab (Just "state") = CStateView
@@ -44,20 +56,21 @@ parseTab (Just "txs") = CTxView
 parseTab _ = CInfoView
 
 
-extractInfo :: ContractViews -> CJ.ContractJSON -> Maybe TJ.Transactions -> ContractView
-extractInfo CInfoView cv _ =
+extractInfo :: ContractViews -> CJ.ContractJSON -> Maybe TJs.Transactions -> Maybe TJ.Transaction -> ContractView
+extractInfo CInfoView cv _ _ =
   ContractInfoView
       (CIVR { civrContractId = CJ.contractId res
-            , blockHeaderHash = CJ.blockHeaderHash block
-            , blockNo = CJ.blockNo block
-            , slotNo = CJ.slotNo block
-            , roleTokenMintingPolicyId = CJ.roleTokenMintingPolicyId res
-            , status = CJ.status res
-            , version = CJ.version res
+            , civrBlockHeaderHash = CJ.blockHeaderHash block
+            , civrBlockNo = CJ.blockNo block
+            , civrSlotNo = CJ.slotNo block
+            , civrRoleTokenMintingPolicyId = CJ.roleTokenMintingPolicyId res
+            , civrTags = CJ.tags res
+            , civrStatus = CJ.status res
+            , civrVersion = CJ.version res
             })
   where res = CJ.resource cv
         block = CJ.block res
-extractInfo CStateView cv _ =
+extractInfo CStateView cv _ _ =
   ContractStateView
       (CSVR { csvrContractId = CJ.contractId res
             , currentContract = CJ.currentContract res
@@ -65,18 +78,60 @@ extractInfo CStateView cv _ =
             , currentState = CJ.state res
             })
   where res = CJ.resource cv
-extractInfo CTxView cv (Just (TJ.Transactions txs)) =
-  ContractTxView . CTVRs (CJ.contractId res) $ map convertTx txs
+extractInfo CTxView CJ.ContractJSON { CJ.resource = CJ.Resource { CJ.contractId = contractId' }
+                                    }
+            (Just (TJs.Transactions { TJs.transactions = txs })) mTx =
+  ContractTxView $ CTVRs { ctvrsContractId = contractId'
+                         , ctvrs = map convertTx $ reverse txs
+                         , ctvrsSelectedTransactionInfo = fmap convertTxDetails mTx
+                         }
   where
-    res = CJ.resource cv
-    convertTx tx = CTVR { ctvrLink = TJ.transaction $ TJ.links tx
-                        , ctvrBlock = TJ.blockNo $ TJ.block tRes
-                        , ctvrSlot = TJ.slotNo $ TJ.block tRes
-                        , ctvrContractId = TJ.contractId tRes
-                        , ctvrTransactionId = TJ.transactionId tRes
+    convertTx TJs.Transaction { TJs.resource = TJs.Resource { TJs.block = TJs.Block { TJs.blockNo = blockNo'
+                                                                                    , TJs.slotNo = slotNo'
+                                                                                    }
+                                                            , TJs.contractId = txContractId
+                                                            , TJs.transactionId = transactionId'
+                                                            }
+                              } =
+                   CTVR { ctvrBlock = blockNo'
+                        , ctvrSlot = slotNo'
+                        , ctvrContractId = txContractId
+                        , ctvrTransactionId = transactionId'
                         }
-      where tRes = TJ.resource tx
-extractInfo _ _ Nothing = ContractViewError "Something went wrong, unable to display"
+extractInfo _ _ Nothing _ = ContractViewError "Something went wrong, unable to display"
+
+convertTxDetails :: TJ.Transaction -> CTVRTDetail
+convertTxDetails TJ.Transaction { TJ.links = TJ.Link { TJ.next = mNext
+                                                     , TJ.previous = mPrev
+                                                     }
+                                , TJ.resource = TJ.Resource { TJ.block = TJ.Block { TJ.blockHeaderHash = txDetailBlockHeaderHash
+                                                                                  , TJ.blockNo = txDetailBlockNo
+                                                                                  , TJ.slotNo = txDetailSlotNo
+                                                                                  }
+                                                            , TJ.inputs = txDetailInputs
+                                                            , TJ.invalidBefore = txDetailInvalidBefore
+                                                            , TJ.invalidHereafter = txDetailInvalidHereafter
+                                                            , TJ.outputContract = txDetailOutputContract
+                                                            , TJ.outputState = txDetailOutputState
+                                                            , TJ.status = txDetailStatus
+                                                            , TJ.tags = txDetailTags
+                                                            , TJ.transactionId = txDetailTransactionId
+                                                            }
+                                }
+  = CTVRTDetail { txPrev= mPrev
+                , txNext= mNext
+                , txBlockHeaderHash = txDetailBlockHeaderHash
+                , txBlockNo = txDetailBlockNo
+                , txSlotNo = txDetailSlotNo
+                , inputs = txDetailInputs
+                , invalidBefore = txDetailInvalidBefore
+                , invalidHereafter = txDetailInvalidHereafter
+                , outputContract = txDetailOutputContract
+                , outputState = txDetailOutputState
+                , txStatus = txDetailStatus
+                , txTags = txDetailTags
+                , transactionId = txDetailTransactionId
+                }
 
 
 allContractViews :: [ContractViews]
@@ -95,7 +150,7 @@ getNavTitle CTxView = "Transactions"
 data ContractViews = CInfoView
                    | CStateView
                    | CTxView
-  deriving (Eq)
+  deriving (Show, Eq)
 
 data ContractView = ContractInfoView CIVR
                   | ContractStateView CSVR
@@ -108,28 +163,30 @@ instance ToMarkup ContractView where
     baseDoc ("Contract - " ++ cid) $ addNavBar CInfoView cid $ renderCIVR cvr
   toMarkup (ContractStateView ccsr@(CSVR {csvrContractId = cid})) =
     baseDoc ("Contract - " ++ cid) $ addNavBar CStateView cid $ renderCSVR ccsr
-  toMarkup (ContractTxView (CTVRs cid ctvrs)) =
-    baseDoc ("Contract - " ++ cid) $ addNavBar CTxView cid $ renderCTVRs ctvrs
+  toMarkup (ContractTxView ctvrs'@CTVRs { ctvrsContractId = cid }) =
+    baseDoc ("Contract - " ++ cid) $ addNavBar CTxView cid $ renderCTVRs ctvrs'
   toMarkup (ContractViewError str) =
     baseDoc "An error occurred" (string ("Error: " ++ str))
 
 data CIVR = CIVR { civrContractId :: String
-                 , blockHeaderHash :: String
-                 , blockNo :: Integer
-                 , slotNo :: Integer
-                 , roleTokenMintingPolicyId :: String
-                 , status :: String
-                 , version :: String
+                 , civrBlockHeaderHash :: String
+                 , civrBlockNo :: Integer
+                 , civrSlotNo :: Integer
+                 , civrRoleTokenMintingPolicyId :: String
+                 , civrTags :: Map String String
+                 , civrStatus :: String
+                 , civrVersion :: String
                  }
 
 renderCIVR :: CIVR -> Html
 renderCIVR (CIVR { civrContractId = cid
-                 , blockHeaderHash = blockHash
-                 , blockNo = blockNum
-                 , slotNo = slotNum
-                 , roleTokenMintingPolicyId = roleMintingPolicyId
-                 , status = contractStatus
-                 , version = marloweVersion
+                 , civrBlockHeaderHash = blockHash
+                 , civrBlockNo = blockNum
+                 , civrSlotNo = slotNum
+                 , civrRoleTokenMintingPolicyId = roleMintingPolicyId
+                 , civrTags = civrTags'
+                 , civrStatus = contractStatus
+                 , civrVersion = marloweVersion
                  }) =
   table $ do tr $ do td $ b "Contract ID"
                      td $ string cid
@@ -141,6 +198,8 @@ renderCIVR (CIVR { civrContractId = cid
                      td $ string (show slotNum)
              tr $ do td $ b "Role Token Minting Policy ID"
                      td $ string roleMintingPolicyId
+             tr $ do td $ b "Tags"
+                     td $ renderTags civrTags'
              tr $ do td $ b "Status"
                      td $ string contractStatus
              tr $ do td $ b "Version"
@@ -167,31 +226,137 @@ renderCSVR (CSVR { csvrContractId = cid
              tr $ do td $ b "Initial contract"
                      td $ renderMContract (Just ic)
 
+data CTVRTDetail = CTVRTDetail
+  {
+    txPrev :: Maybe String,
+    txNext :: Maybe String,
+    txBlockHeaderHash :: String,
+    txBlockNo :: Int,
+    txSlotNo :: Int,
+    inputs :: [Input],
+    invalidBefore :: UTCTime,
+    invalidHereafter :: UTCTime,
+    outputContract :: Maybe Contract,
+    outputState :: Maybe State,
+    txStatus :: String,
+    txTags :: Map String String,
+    transactionId :: String
+  }
+  deriving Show
+
 data CTVR = CTVR
-  { ctvrLink :: String
-  , ctvrBlock :: Integer
+  { ctvrBlock :: Integer
   , ctvrSlot :: Integer
   , ctvrContractId :: String
   , ctvrTransactionId :: String
   }
   deriving Show
 
-data CTVRs = CTVRs String [CTVR]
+data CTVRs = CTVRs {
+    ctvrsContractId ::String
+  , ctvrs :: [CTVR]
+  , ctvrsSelectedTransactionInfo :: Maybe CTVRTDetail
+}
 
 
-renderCTVRs :: [CTVR] -> Html
-renderCTVRs [] = p ! style "color: red" $ string "There are no transactions"
-renderCTVRs ctvrs = table $ do
+renderCTVRs :: CTVRs -> Html
+renderCTVRs CTVRs { ctvrs = [] } = p ! style "color: red" $ string "There are no transactions"
+renderCTVRs CTVRs { ctvrsContractId = ctvrsContractId'
+                  , ctvrs = ctvrs'
+                  , ctvrsSelectedTransactionInfo = ctvrsSelectedTransactionInfo'
+                  } = do
+  table $ do
     tr $ do
       th $ b "Transaction ID"
       th $ b "Block No"
       th $ b "Slot No"
-    forM_ ctvrs makeRow
-  where makeRow ctvr = do
+    forM_ ctvrs' makeRow
+  renderCTVRTDetail ctvrsContractId' ctvrsSelectedTransactionInfo'
+  where makeRow CTVR { ctvrBlock = ctvrBlock'
+                     , ctvrSlot = ctvrSlot'
+                     , ctvrContractId = ctvrContractId'
+                     , ctvrTransactionId = ctvrTransactionId'
+                     } = do
           tr $ do
-            td $ string . ctvrTransactionId $ ctvr
-            td $ toHtml . ctvrBlock $ ctvr
-            td $ toHtml . ctvrSlot $ ctvr
+            td $ if Just ctvrTransactionId' /= fmap transactionId ctvrsSelectedTransactionInfo'
+                 then linkToTransaction ctvrContractId' ctvrTransactionId' ctvrTransactionId'
+                 else string ctvrTransactionId'
+            td $ string $ show ctvrBlock'
+            td $ string $ show ctvrSlot'
+
+renderCTVRTDetail :: String -> Maybe CTVRTDetail -> Html
+renderCTVRTDetail _cid Nothing = do p $ string "Select a transaction to view its details"
+renderCTVRTDetail cid (Just CTVRTDetail { txPrev = txPrev'
+                                        , txNext = txNext'
+                                        , txBlockHeaderHash = txBlockHeaderHash'
+                                        , txBlockNo = txBlockNo'
+                                        , txSlotNo = txSlotNo'
+                                        , inputs = inputs'
+                                        , invalidBefore = invalidBefore'
+                                        , invalidHereafter = invalidHereafter'
+                                        , outputContract = outputContract'
+                                        , outputState = outputState'
+                                        , txStatus = txStatus'
+                                        , txTags = tags'
+                                        , transactionId = transactionId'
+                                        }) =
+  table $ do
+  tr $ do
+    td $ maybe (string previousTransactionLabel) (explorerTransactionLinkFromRuntimeLink previousTransactionLabel) txPrev'
+    td $ maybe (string nextTransactionLabel) (explorerTransactionLinkFromRuntimeLink nextTransactionLabel) txNext'
+  table $ do
+    tr $ do
+      td $ b "Block header hash"
+      td $ string txBlockHeaderHash'
+    tr $ do
+      td $ b "Block number"
+      td $ string $ show txBlockNo'
+    tr $ do
+      td $ b "Slot number"
+      td $ string $ show txSlotNo'
+    tr $ do
+      td $ b "Inputs"
+      td $ do if null inputs' 
+              then string "No inputs"
+              else table $ do
+                     mapM_ (\inp -> do tr $ td $ code $ stringToHtml $ show $ pretty inp) inputs'
+    tr $ do
+      td $ b "Invalid before"
+      td $ makeLocalDateTime invalidBefore'
+    tr $ do
+      td $ b "Invalid after"
+      td $ makeLocalDateTime invalidHereafter'
+    tr $ do
+      td $ b "Output Contract"
+      td $ renderMContract outputContract'
+    tr $ do
+      td $ b "Output State"
+      td $ renderMState outputState'
+    tr $ do
+      td $ b "Status"
+      td $ string txStatus'
+    tr $ do
+      td $ b "Tags"
+      td $ renderTags tags'
+    tr $ do
+      td $ b "Transaction Id"
+      td $ string transactionId'
+  where previousTransactionLabel = "< Previous Transaction"
+        nextTransactionLabel = "Next Transaction >"
+        explorerTransactionLinkFromRuntimeLink label rtTxLink =
+          case split '/' rtTxLink of
+            [_, _, _, tTransactionId] -> linkToTransaction cid tTransactionId label
+            _ -> string label
+
+renderTags :: Map String String -> Html
+renderTags tagMap | Map.null tagMap = string "No tags"
+                  | otherwise = table $ do tr $ do
+                                             th $ b "Tag"
+                                             th $ b "Value"
+                                           mapM_ (\(t, v) -> tr $ do
+                                                               td $ string t
+                                                               td $ string (show v)
+                                                 ) (Map.toList tagMap)
 
 renderParty :: Party -> String
 renderParty (Address ad) = printf "Address: %s" $ unpack ad
@@ -257,9 +422,21 @@ renderMContract Nothing = string "Contract closed"
 renderMContract (Just c) = code $ stringToHtml $ show $ pretty c
 
 addNavBar :: ContractViews -> String -> Html -> Html
-addNavBar cv cid c =
+addNavBar cv cid c = do
   table $ do tr $ do td $ b $ a ! href "listContracts" $ "Contracts List"
                      td $ b "Navigation bar"
                      mapM_ (\ccv -> mkNavLink (cv == ccv) cid (getNavTab ccv) (getNavTitle ccv))
                            allContractViews
-                     c
+  c
+
+linkToTransaction :: String -> String -> String -> Html
+linkToTransaction contractId transactionId' linkText =
+  a ! href (toValue $ generateLink "contractView" [("tab", getNavTab CTxView), ("contractId", contractId), ("transactionId", transactionId')])
+    $ string linkText
+
+mkNavLink :: Bool -> String -> String -> String -> Html
+mkNavLink True _ _ tabTitle =
+  td $ string tabTitle
+mkNavLink False cid tabName tabTitle =
+  td $ a ! href (toValue $ generateLink "contractView" [("tab", tabName), ("contractId", cid)])
+         $ string tabTitle

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -238,15 +238,19 @@ renderTime =
 
 renderMState :: Maybe State -> Html
 renderMState Nothing = string "Contract closed"
-renderMState (Just st) = table $ do
-  tr $ do td $ b "accounts"
-          td . renderMAccounts . accounts $ st
-  tr $ do td $ b "bound values"
-          td . string . renderBoundValues . boundValues $ st
-  tr $ do td $ b "choices"
-          td . string . renderChoices . choices $ st
-  tr $ do td $ b "minTime"
-          td . renderTime . minTime $ st
+renderMState (Just (State { accounts    = accs
+                          , choices     = chos
+                          , boundValues = boundVals
+                          , minTime     = mtime })) =
+  table $ do tr $ do td $ b "accounts"
+                     td $ renderMAccounts accs
+             tr $ do td $ b "bound values"
+                     td $ string $ renderBoundValues boundVals
+             tr $ do td $ b "choices"
+                     td $ string $ renderChoices chos
+             tr $ do td $ b "minTime"
+                     td $ do renderTime mtime
+                             string $ " (POSIX: " ++ show mtime ++ ")"
 
 renderMContract :: Maybe Contract -> Html
 renderMContract Nothing = string "Contract closed"

--- a/src/Explorer/Web/Util.hs
+++ b/src/Explorer/Web/Util.hs
@@ -57,7 +57,6 @@ stringToHtml str = mconcat $ map processLine $ lines str
 generateLink :: String -> [(String, String)] -> String
 generateLink path params = path ++ unpack (renderSimpleQuery True (map (bimap pack pack) params))
 
-
 prettyPrintAmount :: Int -> Integer -> String
 prettyPrintAmount decimalPositions amount = if decimals /= [] then integers ++ '.':decimals else integers
   where (revDecimals, revIntegers) = splitAt decimalPositions $ reverse (show amount)

--- a/src/Explorer/Web/Util.hs
+++ b/src/Explorer/Web/Util.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Explorer.Web.Util
-  ( baseDoc, formatTimeDiff, generateLink, makeLocalDateTime, mkNavLink, prettyPrintAmount, stringToHtml, table, td, th, tr )
+  ( baseDoc, formatTimeDiff, generateLink, linkFor, makeLocalDateTime, prettyPrintAmount, stringToHtml, table, td, th, tr )
   where
 
 import Data.Bifunctor (Bifunctor (bimap))
@@ -20,13 +20,6 @@ baseDoc caption content = docTypeHtml
                                  $ do head $ title $ string caption
                                       body $ do h1 $ string caption
                                                 content
-
-mkNavLink :: Bool -> String -> String -> String -> Html
-mkNavLink True _ _ tabTitle =
-  td $ string tabTitle
-mkNavLink False cid tabName tabTitle =
-  td $ a ! href (toValue $ generateLink "contractView" [("tab", tabName), ("contractId", cid)])
-         $ string tabTitle
 
 table :: Html -> Html
 table = H.table ! style "border: 1px solid black"
@@ -100,4 +93,8 @@ makeLocalDateTime timestampToRender =
         "div.innerHTML = date.toString().split(' (')[0];" ++
         "script.parentNode.insertBefore(div, script);" ++
       "})();")
+
+
+linkFor :: ToValue a => a -> String -> Html
+linkFor x y = a ! href (toValue x) $ string y
 

--- a/src/Language/Marlowe/Runtime/Types/LazyFeed.hs
+++ b/src/Language/Marlowe/Runtime/Types/LazyFeed.hs
@@ -23,9 +23,6 @@ fromExceptTIO :: ExceptT String IO (LazyFeed a) -> LazyFeed a
 fromExceptTIO h = fromIO $ do x <- runExceptT h
                               return $ either errorToLazyFeed id x
 
-
-                     
-
 errorToLazyFeed :: String -> LazyFeed a
 errorToLazyFeed str = LazyFeed $ do return $ ErrorReading str
 

--- a/src/Language/Marlowe/Runtime/Types/TransactionJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/TransactionJSON.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE InstanceSigs #-}
+
+module Language.Marlowe.Runtime.Types.TransactionJSON (Link(..), Block(..), RoleToken(..), Token(..), Resource(..), Transaction(..), getTransaction) where
+
+import Language.Marlowe.Semantics.Types (Contract, State, Input)
+import Data.Map ( Map )
+import Data.Aeson ( FromJSON(parseJSON), withObject, Value, withObject, Value, (.:?), eitherDecode )
+import Data.Aeson.Types ((.:), Parser)
+import Network.HTTP.Client (parseRequest)
+import Network.HTTP.Simple (setRequestMethod, setRequestHeader, httpLBS, getResponseBody)
+import Data.Time (UTCTime)
+
+data Link = Link
+  { next :: Maybe String,
+    previous :: Maybe String
+  }
+  deriving (Show)
+
+data Block = Block
+  { blockHeaderHash :: String,
+    blockNo :: Int,
+    slotNo :: Int
+  }
+  deriving (Show)
+
+newtype RoleToken = RoleToken
+  { role_token :: String
+  }
+  deriving (Show)
+
+data Token = Token
+  { currency_symbol :: String,
+    token_name :: String
+  }
+  deriving (Show)
+
+data Resource = Resource
+  { block :: Block,
+    consumingTx :: Maybe String,
+    continuations :: Maybe String,
+    contractId :: String,
+    inputUtxo :: String,
+    inputs :: [Input],
+    invalidBefore :: UTCTime,
+    invalidHereafter :: UTCTime,
+    outputContract :: Maybe Contract,
+    outputState :: Maybe State,
+    outputUtxo :: Maybe String,
+    status :: String,
+    tags :: Map String String,
+    transactionId :: String
+  }
+  deriving (Show)
+
+data Transaction = Transaction
+  { links :: Link,
+    resource :: Resource
+  }
+  deriving (Show)
+
+instance FromJSON Link where
+  parseJSON :: Value -> Parser Link
+  parseJSON = withObject "Link" $ \v -> do
+    next' <- v .:? "next"
+    previous' <- v .:? "previous"
+    return Link { next = next'
+                , previous = previous' }
+
+instance FromJSON Block where
+  parseJSON :: Value -> Parser Block
+  parseJSON = withObject "Block" $ \v -> do
+    blockHeaderHash' <- v .: "blockHeaderHash"
+    blockNo' <- v .: "blockNo"
+    slotNo' <- v .: "slotNo"
+    return Block { blockHeaderHash = blockHeaderHash'
+                 , blockNo = blockNo'
+                 , slotNo = slotNo' }
+
+instance FromJSON RoleToken where
+  parseJSON :: Value -> Parser RoleToken
+  parseJSON = withObject "RoleToken" $ \v -> do
+    role_token' <- v .: "role_token"
+    return RoleToken { role_token = role_token' }
+
+instance FromJSON Token where
+  parseJSON :: Value -> Parser Token
+  parseJSON = withObject "Token" $ \v -> do
+    currency_symbol' <- v .: "currency_symbol"
+    token_name' <- v .: "token_name"
+    return Token { currency_symbol = currency_symbol'
+                 , token_name = token_name' }
+
+instance FromJSON Resource where
+  parseJSON :: Value -> Parser Resource
+  parseJSON = withObject "Resource" $ \v -> do
+    block' <- v .: "block"
+    consumingTx' <- v .:? "consumingTx"
+    continuations' <- v .:? "continuations"
+    contractId' <- v .: "contractId"
+    inputUtxo' <- v .: "inputUtxo"
+    inputs' <- v .: "inputs"
+    invalidBefore' <- v .: "invalidBefore"
+    invalidHereafter' <- v .: "invalidHereafter"
+    outputContract' <- v .:? "outputContract"
+    outputState' <- v .:? "outputState"
+    outputUtxo' <- v .:? "outputUtxo"
+    status' <- v .: "status"
+    tags' <- v .: "tags"
+    transactionId' <- v .: "transactionId"
+    return Resource { block = block'
+                    , consumingTx = consumingTx'
+                    , continuations = continuations'
+                    , contractId = contractId'
+                    , inputUtxo = inputUtxo'
+                    , inputs = inputs'
+                    , invalidBefore = invalidBefore'
+                    , invalidHereafter = invalidHereafter'
+                    , outputContract = outputContract'
+                    , outputState = outputState'
+                    , outputUtxo = outputUtxo'
+                    , status = status'
+                    , tags = tags'
+                    , transactionId = transactionId' }
+
+instance FromJSON Transaction where
+  parseJSON :: Value -> Parser Transaction
+  parseJSON = withObject "Transaction" $ \v -> do
+    links' <- v .: "links"
+    resource' <- v .: "resource"
+    return Transaction { links = links'
+                       , resource = resource' }
+
+getTransaction :: String -> String -> String -> IO (Either String Transaction)
+getTransaction endpoint tsLink tLink = do
+    initialRequest <- parseRequest $ endpoint ++ tsLink ++ "/" ++ tLink
+    let request = setRequestMethod "GET" $ setRequestHeader "Accept" ["application/json"] initialRequest
+    response <- httpLBS request
+    return $ eitherDecode (getResponseBody response)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -31,7 +31,7 @@ startApp opts = do
 type API
      = Get '[HTML] ContractListView  -- Initial "index" page, http://HOST:PORT/
   :<|> "listContracts" :> QueryParam "page" Int :> Get '[HTML] ContractListView
-  :<|> "contractView" :> QueryParam "tab" String :> QueryParam "contractId" String :> Get '[HTML] ContractView
+  :<|> "contractView" :> QueryParam "tab" String :> QueryParam "contractId" String :> QueryParam "transactionId" String :> Get '[HTML] ContractView
 
 app :: Options -> ContractListCache -> Application
 app opts contractListCache =


### PR DESCRIPTION
This PR:
- Simplifies flow of contractView (using ExceptT)
- Simplifies contract caching logic (using ExceptT)
- Uses JavaScript to display time-date in local time-zone
- Adds POSIX time (in addition to local time-zone time-date)
- Removes unnecessary white space
- Implements transaction detail view