### PR TITLE
PLT-4235 - Add open/closed status and number of transactions to contract list view

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -6,6 +6,12 @@ cradle:
     - path: "./app/Main.hs"
       component: "marlowe-explorer:exe:marlowe-explorer-exe"
 
+    - path: "./src/Explorer/API/GetNumTransactions.hs"
+      component: "marlowe-explorer:lib"
+
+    - path: "./src/Explorer/API/IsContractOpen.hs"
+      component: "marlowe-explorer:lib"
+
     - path: "./src/Explorer/SharedContractCache.hs"
       component: "marlowe-explorer:lib"
 

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -25,6 +25,8 @@ source-repository head
 
 library
   exposed-modules:
+      Explorer.API.GetNumTransactions
+      Explorer.API.IsContractOpen
       Explorer.SharedContractCache
       Explorer.Web.ContractInfoDownload
       Explorer.Web.ContractListView

--- a/src/Explorer/API/GetNumTransactions.hs
+++ b/src/Explorer/API/GetNumTransactions.hs
@@ -1,9 +1,13 @@
-module Explorer.API.GetNumTransactions(getContractNumTransactions) where
+module Explorer.API.GetNumTransactions(getContractNumTransactions, numTransactionsAJAXBox) where
 
 import Servant (throwError)
 import Opts (Options(..), mkUrlPrefix)
 import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJs
 import Data.List (genericLength)
+import Text.Blaze.Html5 (Html, (!))
+import Explorer.Web.Util (generateLink)
+import qualified Text.Blaze.Html5.Attributes as A
+import qualified Text.Blaze.Html5 as H
 
 getContractNumTransactions :: Options -> Maybe [Char] -> IO Integer
 getContractNumTransactions _ Nothing = throwError (userError "Need to specify contract id")
@@ -13,3 +17,27 @@ getContractNumTransactions opts (Just cid) = do
   case ejson of
     Left s -> throwError $ userError $ "Could not fetch contract transactions: " ++ s
     Right TJs.Transactions { TJs.transactions = tList } -> return $ genericLength tList
+
+numTransactionsAJAXBox :: String -> Html
+numTransactionsAJAXBox cid = do
+    let url = generateLink "getNumTransactions" [("contractId", cid)]
+        divId = "numTransFor_" ++ cid
+
+    H.div ! A.id (H.toValue divId) $ H.string "Loading..."
+
+    H.script ! A.type_ (H.toValue "text/javascript") $ H.string $
+        "function getNumTransactions() {\n" ++
+        "  var xhr = new XMLHttpRequest();\n" ++
+        "  xhr.onreadystatechange = function() {\n" ++
+        "    if (xhr.readyState == 4) {\n" ++ 
+        "      if (xhr.status == 200) {\n" ++
+        "        document.getElementById('" ++ divId ++ "').innerHTML = xhr.responseText;\n" ++
+        "      } else {\n" ++
+        "        document.getElementById('" ++ divId ++ "').innerHTML = 'Error';\n" ++
+        "      }\n" ++
+        "    }\n" ++
+        "  };\n" ++
+        "  xhr.open('GET', '" ++ url ++ "', true);\n" ++
+        "  xhr.send();\n" ++
+        "}\n" ++
+        "getNumTransactions();\n"

--- a/src/Explorer/API/GetNumTransactions.hs
+++ b/src/Explorer/API/GetNumTransactions.hs
@@ -1,0 +1,15 @@
+module Explorer.API.GetNumTransactions(getContractNumTransactions) where
+
+import Servant (throwError)
+import Opts (Options(..), mkUrlPrefix)
+import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJs
+import Data.List (genericLength)
+
+getContractNumTransactions :: Options -> Maybe [Char] -> IO Integer
+getContractNumTransactions _ Nothing = throwError (userError "Need to specify contract id")
+getContractNumTransactions opts (Just cid) = do
+  let urlPrefix = mkUrlPrefix opts
+  ejson <- TJs.getContractTransactionsByContractId urlPrefix cid
+  case ejson of
+    Left s -> throwError $ userError $ "Could not fetch contract transactions: " ++ s
+    Right TJs.Transactions { TJs.transactions = tList } -> return $ genericLength tList

--- a/src/Explorer/API/IsContractOpen.hs
+++ b/src/Explorer/API/IsContractOpen.hs
@@ -1,9 +1,13 @@
-module Explorer.API.IsContractOpen(isContractOpen) where
+module Explorer.API.IsContractOpen(isContractOpen, isOpenAJAXBox) where
  
 import Servant (throwError)
 import Opts (Options(..), mkUrlPrefix)
 import qualified Language.Marlowe.Runtime.Types.ContractJSON as CJ
 import Data.Maybe (isJust)
+import Text.Blaze.Html5 (Html, (!))
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+import Explorer.Web.Util (generateLink)
 
 isContractOpen :: Options -> Maybe [Char] -> IO Bool
 isContractOpen _ Nothing = throwError (userError "Need to specify contract id")
@@ -14,3 +18,26 @@ isContractOpen opts (Just cid) = do
     Left s -> throwError $ userError $ "Could not fetch contract info: " ++ s
     Right CJ.ContractJSON { CJ.resource = CJ.Resource { CJ.currentContract = currContract } } -> return $ isJust currContract
 
+isOpenAJAXBox :: String -> Html
+isOpenAJAXBox cid = do
+    let url = generateLink "isContractOpen" [("contractId", cid)]
+        divId = "isOpen_" ++ cid
+
+    H.div ! A.id (H.toValue divId) $ H.string "Loading..."
+
+    H.script ! A.type_ (H.toValue "text/javascript") $ H.string $
+        "function isContractOpen() {\n" ++
+        "  var xhr = new XMLHttpRequest();\n" ++
+        "  xhr.onreadystatechange = function() {\n" ++
+        "    if (xhr.readyState == 4) {\n" ++ 
+        "      if (xhr.status == 200) {\n" ++
+        "        document.getElementById('" ++ divId ++ "').innerHTML = xhr.responseText;\n" ++
+        "      } else {\n" ++
+        "        document.getElementById('" ++ divId ++ "').innerHTML = 'Error';\n" ++
+        "      }\n" ++
+        "    }\n" ++
+        "  };\n" ++
+        "  xhr.open('GET', '" ++ url ++ "', true);\n" ++
+        "  xhr.send();\n" ++
+        "}\n" ++
+        "isContractOpen();\n"

--- a/src/Explorer/API/IsContractOpen.hs
+++ b/src/Explorer/API/IsContractOpen.hs
@@ -1,0 +1,16 @@
+module Explorer.API.IsContractOpen(isContractOpen) where
+ 
+import Servant (throwError)
+import Opts (Options(..), mkUrlPrefix)
+import qualified Language.Marlowe.Runtime.Types.ContractJSON as CJ
+import Data.Maybe (isJust)
+
+isContractOpen :: Options -> Maybe [Char] -> IO Bool
+isContractOpen _ Nothing = throwError (userError "Need to specify contract id")
+isContractOpen opts (Just cid) = do
+  let urlPrefix = mkUrlPrefix opts
+  ejson <- CJ.getContractJSON urlPrefix cid
+  case ejson of
+    Left s -> throwError $ userError $ "Could not fetch contract info: " ++ s
+    Right CJ.ContractJSON { CJ.resource = CJ.Resource { CJ.currentContract = currContract } } -> return $ isJust currContract
+

--- a/src/Explorer/Web/ContractListView.hs
+++ b/src/Explorer/Web/ContractListView.hs
@@ -22,6 +22,8 @@ import qualified Data.Sequence as Seq
 import Data.List (intersperse)
 import qualified Language.Marlowe.Runtime.Types.IndexedSeq as ISeq
 import qualified Language.Marlowe.Runtime.Types.ContractsJSON as CSJ
+import Explorer.API.IsContractOpen (isOpenAJAXBox)
+import Explorer.API.GetNumTransactions (numTransactionsAJAXBox)
 
 data PageInfo = PageInfo {
        currentPage :: Int
@@ -176,15 +178,19 @@ renderCIRs (ContractListView CLVR { timeOfRendering = timeNow
       th $ b "Role token minting policy"
       th $ b "Block No"
       th $ b "Slot No"
+      th $ b "Is open"
+      th $ b "Num transactions"
       th $ b ""
     let makeRow clvr = do
           let cid = clvrContractId clvr
           tr $ do
             td $ a ! href (toValue $ generateLink "contractView" [("tab", "info"), ("contractId", cid)])
               $ string cid
-            td $ renderStr . clvrRoleMintingPolicyId $ clvr
-            td $ toHtml . clvrBlock $ clvr
-            td $ toHtml . clvrSlot $ clvr
+            td $ renderStr $ clvrRoleMintingPolicyId clvr
+            td $ toHtml $ clvrBlock clvr
+            td $ toHtml $ clvrSlot clvr
+            td $ isOpenAJAXBox cid
+            td $ numTransactionsAJAXBox cid
             td $ a ! href (toValue $ clvrBlockExplLink clvr) $ string "Explore"
     forM_ clvrs makeRow
   renderNavBar pinf

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -36,7 +36,7 @@ contractView opts@(Options {optBlockExplorerHost = BlockExplorerHost blockExplHo
   r <- runExceptT (do cjson <- ExceptT $ CJ.getContractJSON urlPrefix cid
                       let link = CJ.transactions $ CJ.links cjson
                       txsjson <- whenMaybe (tab == CTxView)
-                                           $ ExceptT $ TJs.getContractTransactions urlPrefix link
+                                           $ ExceptT $ TJs.getContractTransactionsByLink urlPrefix link
                       let mTxId2 = getIfInContract mTxId txsjson
                       txjson <- forM mTxId2 (ExceptT . TJ.getTransaction urlPrefix link)
                       return $ extractInfo tab blockExplHost cjson txsjson txjson)

--- a/src/Language/Marlowe/Runtime/Types/TransactionsJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/TransactionsJSON.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Language.Marlowe.Runtime.Types.TransactionsJSON (Transaction(..), Links(..), Resource(..), Block(..), Transactions(..), getContractTransactions) where
+module Language.Marlowe.Runtime.Types.TransactionsJSON (Transaction(..), Links(..), Resource(..), Block(..), Transactions(..), getContractTransactionsByContractId, getContractTransactionsByLink) where
 
 import Data.Map (Map)
 import Data.Aeson.Types (FromJSON (parseJSON), Parser, Value, withObject, (.:), (.:?))
 import Network.HTTP.Simple (parseRequest, setRequestMethod, setRequestHeader, httpLBS, getResponseBody)
 import Data.Aeson (eitherDecode)
+import Network.HTTP.Types (urlEncode)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Data.Text (pack, unpack)
 
 data Transaction = Transaction
   { links :: Links
@@ -81,8 +84,16 @@ instance FromJSON Transactions where
     results <- o .: "results"
     return Transactions { transactions = results }
 
-getContractTransactions :: String -> String -> IO (Either String Transactions)
-getContractTransactions endpoint link = do
+getContractTransactionsByContractId :: String -> String -> IO (Either String Transactions)
+getContractTransactionsByContractId endpoint reqContractId = do
+    let reqContractIdUrlEncoded = urlEncode False $ encodeUtf8 $ pack reqContractId
+    initialRequest <- parseRequest $ endpoint ++ "contracts/" ++ unpack (decodeUtf8 reqContractIdUrlEncoded) ++ "/transactions"
+    let request = setRequestMethod "GET" $ setRequestHeader "Accept" ["application/json"] initialRequest
+    response <- httpLBS request
+    return $ eitherDecode (getResponseBody response)
+
+getContractTransactionsByLink :: String -> String -> IO (Either String Transactions)
+getContractTransactionsByLink endpoint link = do
     initialRequest <- parseRequest $ endpoint ++ link
     let request = setRequestMethod "GET" $ setRequestHeader "Accept" ["application/json"] initialRequest
     response <- httpLBS request

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -11,7 +11,7 @@ import Control.Monad.IO.Class ( liftIO )
 import Control.Newtype.Generics ( op )
 import Network.Wai ( Application )
 import Network.Wai.Handler.Warp ( run )
-import Servant ( Proxy(..), hoistServer, serve, type (:<|>)(..), OctetStream, QueryParam, type (:>), Get, Headers, Header )
+import Servant ( Proxy(..), hoistServer, serve, type (:<|>)(..), OctetStream, QueryParam, type (:>), Get, Headers, Header, JSON )
 import Servant.HTML.Blaze ( HTML )
 
 import Explorer.SharedContractCache ( ContractListCache )
@@ -21,6 +21,8 @@ import Language.Marlowe.Runtime.Background ( start )
 import Opts ( Options (optExplorerPort), ExplorerPort (..), mkUrlPrefix )
 import Explorer.Web.ContractInfoDownload (contractDownloadInfo)
 import Data.ByteString.Lazy (ByteString)
+import Explorer.API.GetNumTransactions (getContractNumTransactions)
+import Explorer.API.IsContractOpen (isContractOpen)
 
 startApp :: Options -> IO ()
 startApp opts = do
@@ -35,6 +37,8 @@ type API
   :<|> "listContracts" :> QueryParam "page" Int :> Get '[HTML] ContractListView
   :<|> "contractView" :> QueryParam "tab" String :> QueryParam "contractId" String :> QueryParam "transactionId" String :> Get '[HTML] ContractView
   :<|> "contractDownloadInfo" :> QueryParam "contractId" String :> Get '[OctetStream] (Headers '[Header "Content-Disposition" String] ByteString)
+  :<|> "isContractOpen" :> QueryParam "contractId" String :> Get '[JSON] Bool
+  :<|> "getNumTransactions" :> QueryParam "contractId" String :> Get '[JSON] Integer
 
 app :: Options -> ContractListCache -> Application
 app opts contractListCache =
@@ -43,5 +47,8 @@ app opts contractListCache =
     (contractListView opts contractListCache Nothing
     :<|> contractListView opts contractListCache
     :<|> contractView opts
-    :<|> contractDownloadInfo opts)
+    :<|> contractDownloadInfo opts
+    :<|> isContractOpen opts
+    :<|> getContractNumTransactions opts)
+
 


### PR DESCRIPTION
This PR adds two endpoints, for getting open/closed status for a particular contract respectively, and it modifies the contract list view so that it asynchronously calls them to get that information for every contract