### PR TITLE
PLT-5479 - Link transactionId to explorer in transaction detail

### DIFF
--- a/src/Explorer/API/IsContractOpen.hs
+++ b/src/Explorer/API/IsContractOpen.hs
@@ -31,7 +31,7 @@ isOpenAJAXBox cid = do
         "  xhr.onreadystatechange = function() {\n" ++
         "    if (xhr.readyState == 4) {\n" ++ 
         "      if (xhr.status == 200) {\n" ++
-        "        document.getElementById('" ++ divId ++ "').innerHTML = xhr.responseText;\n" ++
+        "        document.getElementById('" ++ divId ++ "').innerHTML = (xhr.responseText == 'true'?'Open':'Closed');\n" ++
         "      } else {\n" ++
         "        document.getElementById('" ++ divId ++ "').innerHTML = 'Error';\n" ++
         "      }\n" ++

--- a/src/Explorer/Web/ContractListView.hs
+++ b/src/Explorer/Web/ContractListView.hs
@@ -178,7 +178,7 @@ renderCIRs (ContractListView CLVR { timeOfRendering = timeNow
       th $ b "Role token minting policy"
       th $ b "Block No"
       th $ b "Slot No"
-      th $ b "Is open"
+      th $ b "Status"
       th $ b "Num transactions"
       th $ b ""
     let makeRow clvr = do

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -347,7 +347,7 @@ renderCTVRTDetail cid blockExplHost (Just CTVRTDetail { txPrev = txPrev'
       td $ renderTags tags'
     tr $ do
       td $ b "Transaction Id"
-      td $ string transactionId'
+      td $ a ! href (toValue $ "https://" ++ blockExplHost ++ "/transaction/" ++ transactionId') $ string transactionId'
   where previousTransactionLabel = "< Previous Transaction"
         nextTransactionLabel = "Next Transaction >"
         explorerTransactionLinkFromRuntimeLink label rtTxLink =


### PR DESCRIPTION
This PR:
- Links transactionId to explorer in transaction detail
- Replaces the boolean that says whether a contract is open with the words "Open" and "Close" which are clearer, in the contract list