### PR TITLE
PLT-5481 - Link Block Number to explorer

### DIFF
--- a/src/Explorer/Web/Util.hs
+++ b/src/Explorer/Web/Util.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Explorer.Web.Util
-  ( baseDoc, formatTimeDiff, generateLink, linkFor, makeLocalDateTime, prettyPrintAmount, stringToHtml, table, td, th, tr, mkTransactinExplorerLink )
+  ( baseDoc, formatTimeDiff, generateLink, linkFor, makeLocalDateTime, prettyPrintAmount, stringToHtml, table, td, th, tr, mkTransactionExplorerLink , mkBlockExplorerLink )
   where
 
 import Data.Bifunctor (Bifunctor (bimap))
@@ -99,5 +99,8 @@ makeLocalDateTime timestampToRender =
 linkFor :: ToValue a => a -> String -> Html
 linkFor x y = a ! href (toValue x) $ string y
 
-mkTransactinExplorerLink :: String -> String -> String
-mkTransactinExplorerLink = printf "https://%s/transaction/%s" 
+mkTransactionExplorerLink  :: String -> String -> String
+mkTransactionExplorerLink  = printf "https://%s/transaction/%s" 
+
+mkBlockExplorerLink :: String -> Integer -> String
+mkBlockExplorerLink = printf "https://%s/block/%d" 

--- a/src/Language/Marlowe/Runtime/Types/TransactionJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/TransactionJSON.hs
@@ -19,8 +19,8 @@ data Link = Link
 
 data Block = Block
   { blockHeaderHash :: String,
-    blockNo :: Int,
-    slotNo :: Int
+    blockNo :: Integer,
+    slotNo :: Integer
   }
   deriving (Show)
 


### PR DESCRIPTION
- Modify fields both in contract detail view and transaction detail view to be links to the block in the explorer
- Fix typo in the name of the `mkTransactionExplorerLink` function
