### PR TITLE
PLT-5496 - Make state pretty-print choices and bindings too

### DIFF
--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -426,12 +426,12 @@ renderToken (Token currSymbol tokenName) money = (printf "%s (%s)" currSymbol to
 renderBoundValues :: Map ValueId Integer -> Html
 renderBoundValues mapBoundValues = table $ do
   tr $ do
-    th $ b "Choice Id"
+    th $ b "Value Id"
     th $ b "Value"
-  let mkRow (ValueId valueId, choiceValue) =
+  let mkRow (ValueId valueId, bindingValue) =
         tr $ do
           td $ string $ T.unpack valueId
-          td $ string $ show choiceValue
+          td $ string $ prettyPrintAmount 0 bindingValue
   mapM_ mkRow $ Map.toList mapBoundValues
 
 renderChoices :: String -> Map ChoiceId Integer -> Html
@@ -444,7 +444,7 @@ renderChoices blockExplHost mapChoices = table $ do
         tr $ do
           td $ string $ T.unpack choiceId
           td $ renderParty blockExplHost party
-          td $ string $ show choiceValue
+          td $ string $ prettyPrintAmount 0 choiceValue
   mapM_ mkRow $ Map.toList mapChoices
 
 renderTime :: POSIXTime -> Html

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -460,11 +460,11 @@ renderMState blockExplHost (Just (State { accounts    = accs
                           , choices     = chos
                           , boundValues = boundVals
                           , minTime     = mtime })) =
-  table $ do tr $ do td $ b "accounts"
+  table $ do tr $ do td $ b "Accounts"
                      td $ ifEmptyMap accs (string "No accounts") $ renderMAccounts blockExplHost
-             tr $ do td $ b "bound values"
+             tr $ do td $ b "Bound values"
                      td $ ifEmptyMap boundVals (string "No bound values") renderBoundValues
-             tr $ do td $ b "choices"
+             tr $ do td $ b "Choices"
                      td $ ifEmptyMap chos (string "No choices") $ renderChoices blockExplHost
              tr $ do td $ b "minTime"
                      td $ do renderTime mtime

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -428,9 +428,9 @@ renderBoundValues mapBoundValues = table $ do
   tr $ do
     th $ b "Choice Id"
     th $ b "Value"
-  let mkRow (valueId, choiceValue) =
+  let mkRow (ValueId valueId, choiceValue) =
         tr $ do
-          td $ string $ show valueId
+          td $ string $ T.unpack valueId
           td $ string $ show choiceValue
   mapM_ mkRow $ Map.toList mapBoundValues
 
@@ -442,7 +442,7 @@ renderChoices blockExplHost mapChoices = table $ do
     th $ b "Value"
   let mkRow (ChoiceId choiceId party, choiceValue) =
         tr $ do
-          td $ string $ show choiceId
+          td $ string $ T.unpack choiceId
           td $ renderParty blockExplHost party
           td $ string $ show choiceValue
   mapM_ mkRow $ Map.toList mapChoices

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -27,6 +27,7 @@ import Control.Monad.Except (runExceptT, ExceptT (ExceptT))
 import Prelude hiding (div)
 import Data.Time (UTCTime)
 import qualified Data.Text as T
+import qualified Data.Map as M
 
 contractView :: Options -> Maybe String -> Maybe String -> Maybe String -> IO ContractView
 contractView opts@(Options {optBlockExplorerHost = BlockExplorerHost blockExplHost}) mTab (Just cid) mTxId = do
@@ -460,14 +461,19 @@ renderMState blockExplHost (Just (State { accounts    = accs
                           , boundValues = boundVals
                           , minTime     = mtime })) =
   table $ do tr $ do td $ b "accounts"
-                     td $ renderMAccounts blockExplHost accs
+                     td $ ifEmptyMap accs (string "No accounts") $ renderMAccounts blockExplHost
              tr $ do td $ b "bound values"
-                     td $ renderBoundValues boundVals
+                     td $ ifEmptyMap boundVals (string "No bound values") renderBoundValues
              tr $ do td $ b "choices"
-                     td $ renderChoices blockExplHost chos
+                     td $ ifEmptyMap chos (string "No choices") $ renderChoices blockExplHost
              tr $ do td $ b "minTime"
                      td $ do renderTime mtime
                              string $ " (POSIX: " ++ show mtime ++ ")"
+
+ifEmptyMap :: Map a b -> Html -> (Map a b -> Html) -> Html
+ifEmptyMap mapToCheck defaultHtml renderMapFunc
+  | M.null mapToCheck = defaultHtml
+  | otherwise = renderMapFunc mapToCheck
 
 renderMContract :: Maybe Contract -> Html
 renderMContract Nothing = string "Contract closed"


### PR DESCRIPTION
This PR:
- Improves presentation of state by pretty-printing choices and bindings too
- Prints messages instead of empty table when there are no choices/bindings/accounts
- Does some refactorings and small changes (like capitalizing some things)