### PR TITLE
PLT-5819 - Fix tag type to match JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,26 @@ Please note that `hie.yaml` files located outside of the project folder (in ance
 
 Marlowe Explorer provides the following flags that can be used to configure its behavior:
 
-- `--explorer-port PORT` or `-p PORT`: The port number to use for the Marlowe Explorer server. The default value is `8081`.
+- `--title-label TEXT`: The label to be shown together with the title in the Marlowe Explorer in parenthesis. (It can be used to display the name of the network that the Marlowe explorer is deployed to.) The default value is `Preprod`.
+
+- `--explorer-port PORT`: The port number to use for the Marlowe Explorer server. The default value is `8081`.
     
 - `--runtime-host HOSTNAME-OR-IP`: The hostname or IP address of the running Marlowe Runtime server. The default value is `builder`.
     
 - `--runtime-port PORT`: The port number of the running Marlowe Runtime server. The default value is `8080`.
     
-These flags can be set by using the command line when starting the Marlowe Explorer server. For example, to start the server on port `9000` and connect to a runtime server running on the IP address `192.168.0.1` and port `8888`, you could use the following command:
+- `--block-explorer HOST`: The hostname or IP address for exploring Cardano blockchain addresses, transactions, etc. The default value is "preprod.cardanoscan.io".
+
+These flags can be set by using the command line when starting the Marlowe Explorer server. For example, to start the server on port `9000` and connect to a runtime server running `Preview` on the IP address `192.168.0.1` and port `8888`, you could use the following command:
 
 ```bash
-result/bin/marlowe-explorer-exe --explorer-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888
+result/bin/marlowe-explorer-exe --title-label "Preview" --explorer-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888 --block-explorer "preview.cardanoscan.io"
 ```
 
 If you have built the project using Stack you can pass the parameters by adding `--` between the command and the parameters, like this:
 
 ```bash
-stack exec marlowe-explorer-exe -- --explorer-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888
+stack exec marlowe-explorer-exe -- --title-label "Preview" --explorer-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888 --block-explorer "preview.cardanoscan.io"
 ```
 
 

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -51,6 +51,7 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       aeson
+    , aeson-pretty
     , base >=4.7 && <5
     , base16-bytestring
     , blaze-html
@@ -86,6 +87,7 @@ executable marlowe-explorer-exe
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
+    , aeson-pretty
     , base
     , base16-bytestring
     , blaze-html
@@ -120,6 +122,7 @@ test-suite marlowe-explorer-test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
+    , aeson-pretty
     , base
     , base16-bytestring
     , blaze-html

--- a/package.yaml
+++ b/package.yaml
@@ -14,6 +14,7 @@ description:         Please see the README on GitHub at <https://github.com/inpu
 dependencies:
 - base >= 4.7 && < 5
 - aeson
+- aeson-pretty
 - base16-bytestring
 - blaze-html
 - blaze-markup

--- a/src/Explorer/Web/ContractView.hs
+++ b/src/Explorer/Web/ContractView.hs
@@ -15,7 +15,7 @@ import GHC.Utils.Misc (split)
 import Text.Blaze.Html5 ( Html, Markup, ToMarkup(toMarkup), (!), a, b, code, p, string, ToValue (toValue) )
 import Text.Blaze.Html5.Attributes ( href, style )
 import Text.Printf (printf)
-import Explorer.Web.Util ( tr, th, td, table, baseDoc, stringToHtml, prettyPrintAmount, makeLocalDateTime, generateLink, mkTransactionExplorerLink, mkBlockExplorerLink, mkTokenPolicyExplorerLink  )
+import Explorer.Web.Util ( tr, th, td, table, baseDoc, stringToHtml, prettyPrintAmount, makeLocalDateTime, generateLink, mkTransactionExplorerLink, mkBlockExplorerLink, mkTokenPolicyExplorerLink, valueToString  )
 import Language.Marlowe.Pretty ( pretty )
 import qualified Language.Marlowe.Runtime.Types.ContractJSON as CJ
 import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJs
@@ -82,7 +82,7 @@ extractInfo CInfoView blockExplHost CJ.ContractJSON { CJ.resource =
             , civrSlotNo = sltNo
             , civrRoleTokenMintingPolicyId = mintingPolicyId
             , civrRoleTokenMintingPolicyIdLink = mkTokenPolicyExplorerLink blockExplHost mintingPolicyId
-            , civrTags = tagsMap
+            , civrTags = fmap valueToString tagsMap
             , civrStatus = currStatus
             , civrVersion = ver
             })
@@ -125,6 +125,7 @@ extractInfo CTxView blockExplHost CJ.ContractJSON { CJ.resource = CJ.Resource { 
                         }
 extractInfo _ _blockExplHost _ Nothing _ = ContractViewError "Something went wrong, unable to display"
 
+
 convertTxDetails :: String -> TJ.Transaction -> CTVRTDetail
 convertTxDetails blockExplHost TJ.Transaction { TJ.links = TJ.Link { TJ.next = mNext
                                                                    , TJ.previous = mPrev
@@ -155,7 +156,7 @@ convertTxDetails blockExplHost TJ.Transaction { TJ.links = TJ.Link { TJ.next = m
                 , outputContract = txDetailOutputContract
                 , outputState = txDetailOutputState
                 , txStatus = txDetailStatus
-                , txTags = txDetailTags
+                , txTags = fmap valueToString txDetailTags
                 , transactionId = txDetailTransactionId
                 }
 
@@ -396,7 +397,7 @@ renderTags tagMap | Map.null tagMap = string "No tags"
                                              th $ b "Value"
                                            mapM_ (\(t, v) -> tr $ do
                                                                td $ string t
-                                                               td $ string (show v)
+                                                               td $ code $ stringToHtml v
                                                  ) (Map.toList tagMap)
 
 renderParty :: String -> Party -> Html

--- a/src/Explorer/Web/Util.hs
+++ b/src/Explorer/Web/Util.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Explorer.Web.Util
-  ( baseDoc, formatTimeDiff, generateLink, linkFor, makeLocalDateTime, prettyPrintAmount, stringToHtml, table, td, th, tr, mkTransactionExplorerLink , mkBlockExplorerLink, mkTokenPolicyExplorerLink )
+  ( baseDoc, formatTimeDiff, generateLink, linkFor, makeLocalDateTime, prettyPrintAmount, stringToHtml, table, td, th, tr, mkTransactionExplorerLink , mkBlockExplorerLink, mkTokenPolicyExplorerLink, valueToString )
   where
 
 import Data.Bifunctor (Bifunctor (bimap))
@@ -14,6 +14,9 @@ import Text.Blaze.Html5 ( body, docTypeHtml, h1, head, html, title,
 import Text.Blaze.Html5.Attributes ( style, lang, href, type_ )
 import Data.Time (UTCTime, NominalDiffTime)
 import Text.Printf (printf)
+import Data.Aeson (Value)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.ByteString.Lazy (toStrict)
 
 baseDoc :: String -> Html -> Html
 baseDoc caption content = docTypeHtml
@@ -107,3 +110,6 @@ mkBlockExplorerLink = printf "https://%s/block/%d"
 
 mkTokenPolicyExplorerLink :: String -> String -> String
 mkTokenPolicyExplorerLink = printf "https://%s/tokenPolicy/%s"
+
+valueToString :: Value -> String
+valueToString = unpack . toStrict . encodePretty

--- a/src/Language/Marlowe/Runtime/Types/ContractJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/ContractJSON.hs
@@ -38,7 +38,7 @@ data Resource = Resource
   , roleTokenMintingPolicyId :: String
   , state :: Maybe State
   , status :: String
-  , tags :: Map String String
+  , tags :: Map String Value
   , version :: String
   } deriving (Show, Eq)
 

--- a/src/Language/Marlowe/Runtime/Types/TransactionJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/TransactionJSON.hs
@@ -48,7 +48,7 @@ data Resource = Resource
     outputState :: Maybe State,
     outputUtxo :: Maybe String,
     status :: String,
-    tags :: Map String String,
+    tags :: Map String Value,
     transactionId :: String
   }
   deriving (Show)

--- a/src/Language/Marlowe/Runtime/Types/TransactionsJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/TransactionsJSON.hs
@@ -23,7 +23,7 @@ data Resource = Resource
   { block :: Block
   , contractId :: String
   , status :: String
-  , tags :: Map String String
+  , tags :: Map String Value
   , transactionId :: String
   , utxo :: Maybe String
   } deriving (Show, Eq)


### PR DESCRIPTION
This PR:
- Fixes a bug that made the contract detailed view crash for contracts with tags with something other than a `String` as one of the values. It now pretty prints the values as JSON
- Updates the README.md to describe the options `title-label` and `block-explorer`