### PR TITLE
PLT-5841 - Use paginated queries for fetching transactions from Runtime

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -42,6 +42,9 @@ cradle:
     - path: "./src/Language/Marlowe/Runtime/Types/ContractsJSON.hs"
       component: "marlowe-explorer:lib"
 
+    - path: "./src/Language/Marlowe/Runtime/Types/General.hs"
+      component: "marlowe-explorer:lib"
+
     - path: "./src/Language/Marlowe/Runtime/Types/IndexedSeq.hs"
       component: "marlowe-explorer:lib"
 

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -37,6 +37,7 @@ library
       Language.Marlowe.Runtime.ContractCaching
       Language.Marlowe.Runtime.Types.ContractJSON
       Language.Marlowe.Runtime.Types.ContractsJSON
+      Language.Marlowe.Runtime.Types.General
       Language.Marlowe.Runtime.Types.IndexedSeq
       Language.Marlowe.Runtime.Types.LazyFeed
       Language.Marlowe.Runtime.Types.TransactionJSON

--- a/src/Language/Marlowe/Runtime/ContractCaching.hs
+++ b/src/Language/Marlowe/Runtime/ContractCaching.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Language.Marlowe.Runtime.ContractCaching (refreshContracts) where
 
-import Language.Marlowe.Runtime.Types.ContractsJSON ( Range(..), ContractList(..), ContractListISeq, ResultList(ResultList, results), ContractInList )
+import Language.Marlowe.Runtime.Types.ContractsJSON ( ContractList(..), ContractListISeq, ResultList(ResultList, results), ContractInList )
 import qualified Language.Marlowe.Runtime.Types.LazyFeed as LazyFeed
 import qualified Language.Marlowe.Runtime.Types.IndexedSeq as ISeq
 import Language.Marlowe.Runtime.Types.LazyFeed (LazyFeed)
-import Data.ByteString (ByteString)
-import Network.HTTP.Simple (HttpException, Request, parseRequest, setRequestHeader, setRequestMethod, httpLBS, getResponseBody, getResponseHeader)
+import Network.HTTP.Simple (HttpException, parseRequest, setRequestHeader, setRequestMethod, httpLBS, getResponseBody, getResponseHeader)
 import Data.Time.Clock (getCurrentTime)
 import Data.Foldable (foldl')
 import Control.Exception (try, Exception (displayException))
@@ -14,6 +13,7 @@ import Data.Aeson (eitherDecode)
 import Control.Monad.Except (ExceptT(ExceptT))
 import Control.Error.Util (hoistEither)
 import Data.Either.Extra (mapLeft)
+import Language.Marlowe.Runtime.Types.General (Range (..), setRangeHeader, parseRangeHeader)
 
 refreshContracts :: String -> ContractListISeq -> IO (Either String ContractList)
 refreshContracts endpoint lOldChain = do
@@ -37,14 +37,6 @@ completeOldContractList _ Nothing = Left ISeq.empty
 
 getAllContracts :: String -> LazyFeed ContractInList
 getAllContracts endpoint = getAllContracts' endpoint Start
-
-setRangeHeader :: Range -> Request -> Request
-setRangeHeader (Next bs) = setRequestHeader "Range" [bs]
-setRangeHeader _ = id
-
-parseRangeHeader :: [ByteString] -> Range
-parseRangeHeader [bs] = Next bs
-parseRangeHeader _ = Done
 
 getAllContracts' :: String -> Range -> LazyFeed ContractInList
 getAllContracts' _endpoint Done = LazyFeed.emptyLazyFeed

--- a/src/Language/Marlowe/Runtime/Types/ContractsJSON.hs
+++ b/src/Language/Marlowe/Runtime/Types/ContractsJSON.hs
@@ -9,7 +9,6 @@ module Language.Marlowe.Runtime.Types.ContractsJSON
   , ContractListISeq
   , ContractList(..)
   , ContractLinks(..)
-  , Range(..)
   , Resource(..)
   , ResultList(..)
   )
@@ -17,7 +16,6 @@ module Language.Marlowe.Runtime.Types.ContractsJSON
 
 import Control.Exception ( Exception(displayException) )
 import Data.Aeson ( withObject, (.:), FromJSON(parseJSON), Value )
-import Data.ByteString ( ByteString )
 import Data.Time.Clock ( UTCTime )
 import Network.HTTP.Simple ( HttpException )
 import Language.Marlowe.Runtime.Types.IndexedSeq (IndexedSeq, Indexed (getIdentifier))
@@ -111,8 +109,3 @@ instance Exception ContractListFetchingException where
   displayException (DecodingException msg) = "Decoding exception: " ++ msg
   displayException (RequestException subException) = "Exception querying runtime for contracts: " ++ displayException subException
 
-data Range
-  = Start
-  | Next ByteString
-  | Done
-  deriving (Eq, Show)

--- a/src/Language/Marlowe/Runtime/Types/General.hs
+++ b/src/Language/Marlowe/Runtime/Types/General.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.Marlowe.Runtime.Types.General(Range(..), setRangeHeader, parseRangeHeader) where
+
+import Data.ByteString (ByteString)
+import Network.HTTP.Client (Request)
+import Network.HTTP.Simple (setRequestHeader)
+
+data Range
+  = Start
+  | Next ByteString
+  | Done
+  deriving (Eq, Show)
+
+setRangeHeader :: Range -> Request -> Request
+setRangeHeader (Next bs) = setRequestHeader "Range" [bs]
+setRangeHeader _ = id
+
+parseRangeHeader :: [ByteString] -> Range
+parseRangeHeader [bs] = Next bs
+parseRangeHeader _ = Done


### PR DESCRIPTION
This PR modifies the way the Marlowe Explorer queries the Marlowe Runtime to get transactions corresponding to a given contract. Previously, only up to 100 transactions were fetched, due to the pagination mechanism of Marlowe Runtime. Now all the pages are iteratively queried and paginated