### PR TITLE
PLT-5903 - Add health check endpoint to Marlowe Explorer

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -9,6 +9,9 @@ cradle:
     - path: "./src/Explorer/API/GetNumTransactions.hs"
       component: "marlowe-explorer:lib"
 
+    - path: "./src/Explorer/API/HealthCheck.hs"
+      component: "marlowe-explorer:lib"
+
     - path: "./src/Explorer/API/IsContractOpen.hs"
       component: "marlowe-explorer:lib"
 

--- a/marlowe-explorer.cabal
+++ b/marlowe-explorer.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Explorer.API.GetNumTransactions
+      Explorer.API.HealthCheck
       Explorer.API.IsContractOpen
       Explorer.SharedContractCache
       Explorer.Web.ContractInfoDownload

--- a/src/Explorer/API/HealthCheck.hs
+++ b/src/Explorer/API/HealthCheck.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Explorer.API.HealthCheck(HealthCheckResult(..), healthCheck) where
+
+import Data.Aeson (ToJSON)
+import GHC.Generics (Generic)
+import Explorer.SharedContractCache (ContractListCache, readContractList)
+import Language.Marlowe.Runtime.Types.ContractsJSON (ContractList(..))
+import Data.Time (getCurrentTime, diffUTCTime)
+
+data HealthCheckResult = HealthCheckResult
+  { alive :: Bool
+  , ready :: Bool
+  , healthy :: Bool
+  , millisecondsSinceLastUpdate :: Maybe Integer
+  } deriving (Show, Eq, Generic, ToJSON)
+
+healthCheck :: ContractListCache -> IO HealthCheckResult
+healthCheck cache = do
+    ContractList { clRetrievedTime = mRetrievedTime } <- readContractList cache
+    now <- getCurrentTime
+    pure $ case mRetrievedTime of
+            Nothing -> HealthCheckResult
+                         { alive = True
+                         , ready = False
+                         , healthy = True
+                         , millisecondsSinceLastUpdate = Nothing
+                         }
+            Just lastUpdated ->
+               let millisSinceLastUpdated = round (1000 * (now `diffUTCTime` lastUpdated)) in
+               HealthCheckResult
+                 { alive = True
+                 , ready = True
+                 , healthy = millisSinceLastUpdated < 60000 -- Healthy if it was updated in the last minute
+                 , millisecondsSinceLastUpdate = Just millisSinceLastUpdated
+                 }

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -23,6 +23,7 @@ import Explorer.Web.ContractInfoDownload (contractDownloadInfo)
 import Data.ByteString.Lazy (ByteString)
 import Explorer.API.GetNumTransactions (getContractNumTransactions)
 import Explorer.API.IsContractOpen (isContractOpen)
+import Explorer.API.HealthCheck (HealthCheckResult, healthCheck)
 
 startApp :: Options -> IO ()
 startApp opts = do
@@ -39,6 +40,7 @@ type API
   :<|> "contractDownloadInfo" :> QueryParam "contractId" String :> Get '[OctetStream] (Headers '[Header "Content-Disposition" String] ByteString)
   :<|> "isContractOpen" :> QueryParam "contractId" String :> Get '[JSON] Bool
   :<|> "getNumTransactions" :> QueryParam "contractId" String :> Get '[JSON] Integer
+  :<|> "health" :> Get '[JSON] HealthCheckResult
 
 app :: Options -> ContractListCache -> Application
 app opts contractListCache =
@@ -49,6 +51,8 @@ app opts contractListCache =
     :<|> contractView opts
     :<|> contractDownloadInfo opts
     :<|> isContractOpen opts
-    :<|> getContractNumTransactions opts)
+    :<|> getContractNumTransactions opts
+    :<|> healthCheck contractListCache)
+
 
 


### PR DESCRIPTION
This PR adds a checkpoint for checking the health of a Marlowe Explorer deployment.
The endpoint is `/health` and it returns a JSON object with the following keys:
- `alive` - Boolean that determines the service is on (it is always true, if the service is off, the endpoint will just not work)
- `ready` - Boolean that determines whether the service has caught up (at the beginning is false, and becomes true after the first sync completes)
- `healthy` - Boolean that determines whether the service is healthy (currently whether the system has synced in the last 60 seconds, or is still in setup phase)
- `millisecondsSinceLastUpdate` - Number of milliseconds since last update or `null` if the system hasn't sync'd yet