### PR TITLE
PLT-7008 - Rename marlowe-explorer to marlowe-scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for `explorer`
+# Changelog for `marlowe-scan`
 
 All notable changes to this project will be documented in this file.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Marlowe Explorer
+# MarloweScan
 
-Marlowe Explorer is a tool that allows you to explore on-chain Marlowe contracts and watch their execution in Marlowe terms. This document provides instructions on how to build and develop the Marlowe Explorer tool.
+MarloweScan is a tool that allows you to explore on-chain Marlowe contracts and watch their execution in Marlowe terms. This document provides instructions on how to build and develop the MarloweScan tool.
 
 ## Using Nix
 
-This repo provides a `shell.nix` file that can be used for developing and building Marlowe Explorer without having to worry about dependencies.
+This repo provides a `shell.nix` file that can be used for developing and building MarloweScan without having to worry about dependencies.
 
 ### Building with Nix
 
-To build Marlowe Explorer with Nix, you can use the `nix-build` command with `shell.nix`:
+To build MarloweScan with Nix, you can use the `nix-build` command with `shell.nix`:
 
 ```bash
 nix-build shell.nix
 ```
 
-The resulting executable will be made available in `result/bin/marlowe-explorer-exe`
+The resulting executable will be made available in `result/bin/marlowe-scan-exe`
 
 ### Development shell
 
@@ -32,29 +32,29 @@ In order to take advantage of caching, you can use the `https://nixos.org/channe
 
 ## Using Stack
 
-To build Marlowe Explorer with Stack you just need to write:
+To build MarloweScan with Stack you just need to write:
 
 ```bash
 stack build
 ```
 
-To run Marlowe Explorer with Stack, you can use the following command:
+To run MarloweScan with Stack, you can use the following command:
 
 ```bash
-stack exec marlowe-explorer-exe
+stack exec marlowe-scan-exe
 ```
 
 Both these things can be done from within the development environment, and it will set up Stack for you.
 
 ## Using Cabal
 
-To build Marlowe Explorer with Cabal, you can use the following command:
+To build MarloweScan with Cabal, you can use the following command:
 
 ```bash
 cabal build
 ```
 
-To run Marlowe Explorer with Cabal, you can use the following command:
+To run MarloweScan with Cabal, you can use the following command:
 
 ```bash
 cabal run
@@ -64,7 +64,7 @@ Both these things can be done from within the development environment, and it wi
 
 ## Updating hie.yaml
 
-If you add or move or rename Haskell modules, you will need to update the `hie.yaml` file, which is used by the Haskell Language Server (HLS), you can use the following command from within the Nix shell and the `marlowe-explorer` root folder:
+If you add or move or rename Haskell modules, you will need to update the `hie.yaml` file, which is used by the Haskell Language Server (HLS), you can use the following command from within the Nix shell and the `marlowe-scan` root folder:
 
 ```bash
 fix-hie
@@ -80,11 +80,11 @@ Please note that `hie.yaml` files located outside of the project folder (in ance
 
 ## Executable parameters
 
-Marlowe Explorer provides the following flags that can be used to configure its behavior:
+MarloweScan provides the following flags that can be used to configure its behavior:
 
-- `--title-label TEXT`: The label to be shown together with the title in the Marlowe Explorer in parenthesis. (It can be used to display the name of the network that the Marlowe explorer is deployed to.) The default value is `Preprod`.
+- `--title-label TEXT`: The label to be shown together with the title in the MarloweScan in parenthesis. (It can be used to display the name of the network that MarloweScan is deployed to.) The default value is `Preprod`.
 
-- `--explorer-port PORT`: The port number to use for the Marlowe Explorer server. The default value is `8081`.
+- `--marlowe-scan-port PORT`: The port number to use for the MarloweScan server. The default value is `8081`.
     
 - `--runtime-host HOSTNAME-OR-IP`: The hostname or IP address of the running Marlowe Runtime server. The default value is `builder`.
     
@@ -92,16 +92,16 @@ Marlowe Explorer provides the following flags that can be used to configure its 
     
 - `--block-explorer HOST`: The hostname or IP address for exploring Cardano blockchain addresses, transactions, etc. The default value is "preprod.cardanoscan.io".
 
-These flags can be set by using the command line when starting the Marlowe Explorer server. For example, to start the server on port `9000` and connect to a runtime server running `Preview` on the IP address `192.168.0.1` and port `8888`, you could use the following command:
+These flags can be set by using the command line when starting the MarloweScan server. For example, to start the server on port `9000` and connect to a runtime server running `Preview` on the IP address `192.168.0.1` and port `8888`, you could use the following command:
 
 ```bash
-result/bin/marlowe-explorer-exe --title-label "Preview" --explorer-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888 --block-explorer "preview.cardanoscan.io"
+result/bin/marlowe-scan-exe --title-label "Preview" --marlowe-scan-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888 --block-explorer "preview.cardanoscan.io"
 ```
 
 If you have built the project using Stack you can pass the parameters by adding `--` between the command and the parameters, like this:
 
 ```bash
-stack exec marlowe-explorer-exe -- --title-label "Preview" --explorer-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888 --block-explorer "preview.cardanoscan.io"
+stack exec marlowe-scan-exe -- --title-label "Preview" --marlowe-scan-port 9000 --runtime-host 192.168.0.1 --runtime-port 8888 --block-explorer "preview.cardanoscan.io"
 ```
 
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,85 +1,85 @@
 cradle:
   stack:
     - path: "./test/Spec.hs"
-      component: "marlowe-explorer:test:marlowe-explorer-test"
+      component: "marlowe-scan:test:marlowe-scan-test"
 
     - path: "./app/Main.hs"
-      component: "marlowe-explorer:exe:marlowe-explorer-exe"
-
-    - path: "./src/Explorer/API/GetNumTransactions.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/API/HealthCheck.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/API/IsContractOpen.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Resources/Data.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Resources/Helpers.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Resources/MimeTypes.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/SharedContractCache.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Web/ContractInfoDownload.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Web/ContractListView.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Web/ContractView.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Web/Pagination.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Web/PrettyHtml.hs"
-      component: "marlowe-explorer:lib"
-
-    - path: "./src/Explorer/Web/Util.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:exe:marlowe-scan-exe"
 
     - path: "./src/Language/Marlowe/Pretty.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Background.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/ContractCaching.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/ContractJSON.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/ContractsJSON.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/General.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/IndexedSeq.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/LazyFeed.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/TransactionJSON.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Runtime/Types/TransactionsJSON.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Language/Marlowe/Semantics/Types.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Lib.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
 
     - path: "./src/Opts.hs"
-      component: "marlowe-explorer:lib"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/API/GetNumTransactions.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/API/HealthCheck.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/API/IsContractOpen.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Resources/Data.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Resources/Helpers.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Resources/MimeTypes.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/SharedContractCache.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Web/ContractInfoDownload.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Web/ContractListView.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Web/ContractView.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Web/Pagination.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Web/PrettyHtml.hs"
+      component: "marlowe-scan:lib"
+
+    - path: "./src/Scanner/Web/Util.hs"
+      component: "marlowe-scan:lib"

--- a/marlowe-scan.cabal
+++ b/marlowe-scan.cabal
@@ -4,11 +4,11 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 
-name:           marlowe-explorer
+name:           marlowe-scan
 version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/input-output-hk/marlowe-explorer>
-homepage:       https://github.com/input-ouptut-hk/marlowe-explorer#readme
-bug-reports:    https://github.com/input-ouptut-hk/marlowe-explorer/issues
+description:    Please see the README on GitHub at <https://github.com/input-output-hk/marlowe-scan>
+homepage:       https://github.com/input-ouptut-hk/marlowe-scan#readme
+bug-reports:    https://github.com/input-ouptut-hk/marlowe-scan/issues
 author:         Input Output
 maintainer:     Input Output
 copyright:      2023 Input Output
@@ -21,23 +21,10 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/input-ouptut-hk/marlowe-explorer
+  location: https://github.com/input-ouptut-hk/marlowe-scan
 
 library
   exposed-modules:
-      Explorer.API.GetNumTransactions
-      Explorer.API.HealthCheck
-      Explorer.API.IsContractOpen
-      Explorer.Resources.Data
-      Explorer.Resources.Helpers
-      Explorer.Resources.MimeTypes
-      Explorer.SharedContractCache
-      Explorer.Web.ContractInfoDownload
-      Explorer.Web.ContractListView
-      Explorer.Web.ContractView
-      Explorer.Web.Pagination
-      Explorer.Web.PrettyHtml
-      Explorer.Web.Util
       Language.Marlowe.Pretty
       Language.Marlowe.Runtime.Background
       Language.Marlowe.Runtime.ContractCaching
@@ -51,8 +38,21 @@ library
       Language.Marlowe.Semantics.Types
       Lib
       Opts
+      Scanner.API.GetNumTransactions
+      Scanner.API.HealthCheck
+      Scanner.API.IsContractOpen
+      Scanner.Resources.Data
+      Scanner.Resources.Helpers
+      Scanner.Resources.MimeTypes
+      Scanner.SharedContractCache
+      Scanner.Web.ContractInfoDownload
+      Scanner.Web.ContractListView
+      Scanner.Web.ContractView
+      Scanner.Web.Pagination
+      Scanner.Web.PrettyHtml
+      Scanner.Web.Util
   other-modules:
-      Paths_marlowe_explorer
+      Paths_marlowe_scan
   hs-source-dirs:
       src
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
@@ -89,10 +89,10 @@ library
     , zip-archive
   default-language: Haskell2010
 
-executable marlowe-explorer-exe
+executable marlowe-scan-exe
   main-is: Main.hs
   other-modules:
-      Paths_marlowe_explorer
+      Paths_marlowe_scan
   hs-source-dirs:
       app
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
@@ -113,7 +113,7 @@ executable marlowe-explorer-exe
     , http-conduit
     , http-media
     , http-types
-    , marlowe-explorer
+    , marlowe-scan
     , newtype-generics
     , scientific
     , servant-blaze
@@ -127,11 +127,11 @@ executable marlowe-explorer-exe
     , zip-archive
   default-language: Haskell2010
 
-test-suite marlowe-explorer-test
+test-suite marlowe-scan-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
-      Paths_marlowe_explorer
+      Paths_marlowe_scan
   hs-source-dirs:
       test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
@@ -154,7 +154,7 @@ test-suite marlowe-explorer-test
     , http-conduit
     , http-media
     , http-types
-    , marlowe-explorer
+    , marlowe-scan
     , scientific
     , servant-blaze
     , servant-server

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
-name:                marlowe-explorer
+name:                marlowe-scan
 version:             0.1.0.0
-github:              "input-ouptut-hk/marlowe-explorer"
+github:              "input-ouptut-hk/marlowe-scan"
 license:             Apache-2.0
 author:              "Input Output"
 copyright:           "2023 Input Output"
@@ -9,7 +9,7 @@ extra-source-files:
 - README.md
 - CHANGELOG.md
 
-description:         Please see the README on GitHub at <https://github.com/input-output-hk/marlowe-explorer>
+description:         Please see the README on GitHub at <https://github.com/input-output-hk/marlowe-scan>
 
 dependencies:
 - base >= 4.7 && < 5
@@ -59,7 +59,7 @@ library:
   - time
 
 executables:
-  marlowe-explorer-exe:
+  marlowe-scan-exe:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -68,11 +68,11 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - base
-    - marlowe-explorer
+    - marlowe-scan
     - newtype-generics
 
 tests:
-  marlowe-explorer-test:
+  marlowe-scan-test:
     main:                Spec.hs
     source-dirs:         test
     ghc-options:
@@ -81,7 +81,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - base
-    - marlowe-explorer
+    - marlowe-scan
     - hspec
     - hspec-wai
     - aeson

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ let
       , http-conduit, http-types, errors, zip-archive
       }:
       mkDerivation {
-        pname = "marlowe-explorer";
+        pname = "marlowe-scan";
         version = "0.1.0.0";
         src = ./.;
         isLibrary = false;

--- a/src/Language/Marlowe/Runtime/Background.hs
+++ b/src/Language/Marlowe/Runtime/Background.hs
@@ -7,7 +7,7 @@ module Language.Marlowe.Runtime.Background
 
 import Control.Concurrent ( forkIO, threadDelay, myThreadId )
 
-import Explorer.SharedContractCache ( ContractListCache, newContractList, readContractList, writeContractList, ContractList (..) )
+import Scanner.SharedContractCache ( ContractListCache, newContractList, readContractList, writeContractList, ContractList (..) )
 import Language.Marlowe.Runtime.ContractCaching (refreshContracts)
 import GHC.GHCi.Helpers (flushAll)
 import GHC.Conc (ThreadId)

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -13,25 +13,25 @@ import Network.Wai ( Application )
 import Network.Wai.Handler.Warp ( run )
 import Servant ( Proxy(..), hoistServer, serve, type (:<|>)(..), OctetStream, QueryParam, type (:>), Get, Headers, Header, JSON, HasServer (ServerT) )
 
-import Explorer.SharedContractCache ( ContractListCacheReader )
-import Explorer.Web.ContractListView ( ContractListView (..), contractListView )
-import Explorer.Web.ContractView ( ContractView (..), contractView )
+import Scanner.SharedContractCache ( ContractListCacheReader )
+import Scanner.Web.ContractListView ( ContractListView (..), contractListView )
+import Scanner.Web.ContractView ( ContractView (..), contractView )
 import Language.Marlowe.Runtime.Background ( start )
-import Opts ( Options (optExplorerPort), ExplorerPort (..), mkUrlPrefix )
-import Explorer.Web.ContractInfoDownload (contractDownloadInfo)
+import Opts ( Options (optMarloweScanPort), MarloweScan (..), mkUrlPrefix )
+import Scanner.Web.ContractInfoDownload (contractDownloadInfo)
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString as BS
-import Explorer.API.GetNumTransactions (getContractNumTransactions)
-import Explorer.API.IsContractOpen (isContractOpen)
-import Explorer.API.HealthCheck (HealthCheckResult, healthCheck)
-import Explorer.Resources.Data (cssStylesheet, activeLight, greenStatus, inactiveLight, logo, magnifyingGlass, amberStatus, redStatus, downloadIcon, blockHeaderHashIcon, blockNoIcon, bookIcon, metadataIcon, roleTokenMintingPolicyIdIcon, slotNoIcon, statusIcon, versionIcon, prismJS, prismCSS, marlowePrismJS, marlowePrismCSS, stateIcon, arrowDropDown, alarmClock, circleIcon)
-import Explorer.Resources.MimeTypes (CSS, SVG, JS)
+import Scanner.API.GetNumTransactions (getContractNumTransactions)
+import Scanner.API.IsContractOpen (isContractOpen)
+import Scanner.API.HealthCheck (HealthCheckResult, healthCheck)
+import Scanner.Resources.Data (cssStylesheet, activeLight, greenStatus, inactiveLight, logo, magnifyingGlass, amberStatus, redStatus, downloadIcon, blockHeaderHashIcon, blockNoIcon, bookIcon, metadataIcon, roleTokenMintingPolicyIdIcon, slotNoIcon, statusIcon, versionIcon, prismJS, prismCSS, marlowePrismJS, marlowePrismCSS, stateIcon, arrowDropDown, alarmClock, circleIcon)
+import Scanner.Resources.MimeTypes (CSS, SVG, JS)
 import Servant.HTML.Blaze (HTML)
 
 startApp :: Options -> IO ()
 startApp opts = do
-  let eport = op ExplorerPort . optExplorerPort $ opts
-  putStrLn $ "Marlowe Explorer server started, available at localhost:"
+  let eport = op MarloweScan . optMarloweScanPort $ opts
+  putStrLn $ "MarloweScan server started, available at localhost:"
     <> show eport
   contractListCache <- start $ mkUrlPrefix opts
   run eport $ app opts contractListCache

--- a/src/Opts.hs
+++ b/src/Opts.hs
@@ -3,7 +3,7 @@
 module Opts
   ( TitleLabel (..)
   , BlockExplorerHost (..)
-  , ExplorerPort (..)
+  , MarloweScan (..)
   , RuntimeHost (..)
   , RuntimePort (..)
   , Options (..)
@@ -24,10 +24,10 @@ newtype TitleLabel = TitleLabel String
 
 instance Newtype TitleLabel
 
-newtype ExplorerPort = ExplorerPort Int
+newtype MarloweScan = MarloweScan Int
   deriving (Generic, Show)
 
-instance Newtype ExplorerPort
+instance Newtype MarloweScan
 
 newtype RuntimeHost = RuntimeHost String
   deriving (Generic, Show)
@@ -46,7 +46,7 @@ instance Newtype BlockExplorerHost
 
 data Options = Options
   { optTitleLabel :: TitleLabel
-  , optExplorerPort :: ExplorerPort
+  , optMarloweScanPort :: MarloweScan
   , optRuntimeHost :: RuntimeHost
   , optRuntimePort :: RuntimePort
   , optBlockExplorerHost :: BlockExplorerHost
@@ -58,16 +58,16 @@ parser = Options
   <$> ( TitleLabel <$> strOption
         (  long "title-label"
         <> metavar "TEXT"
-        <> help ("Label to be shown together with the title in the Marlowe Explorer in parenthesis. " ++
-                 "(It can be used to display the name of the network that the Marlowe explorer is deployed to.)")
+        <> help ("Label to be shown together with the title in MarloweScan in parenthesis. " ++
+                 "(It can be used to display the name of the network that MarloweScan is deployed to.)")
         <> showDefault
         <> value "Preprod"
         )
       )
-  <*> ( ExplorerPort <$> option auto
-        (  long "explorer-port"
+  <*> ( MarloweScan <$> option auto
+        (  long "marlowe-scan-port"
         <> metavar "PORT"
-        <> help "Port number to use for this Marlowe Explorer server"
+        <> help "Port number to use for this MarloweScan server"
         <> showDefault
         <> value 8081
         )
@@ -100,7 +100,7 @@ parser = Options
 parseOpts :: IO Options
 parseOpts = do
   execParser $ info (parser <**> helper)
-    (  header "Marlowe Explorer server"
+    (  header "MarloweScan server"
     )
 
 mkUrlPrefix :: Options -> String

--- a/src/Scanner/API/GetNumTransactions.hs
+++ b/src/Scanner/API/GetNumTransactions.hs
@@ -1,11 +1,11 @@
-module Explorer.API.GetNumTransactions(getContractNumTransactions, numTransactionsAJAXBox) where
+module Scanner.API.GetNumTransactions(getContractNumTransactions, numTransactionsAJAXBox) where
 
 import Servant (throwError)
 import Opts (Options(..), mkUrlPrefix)
 import qualified Language.Marlowe.Runtime.Types.TransactionsJSON as TJs
 import Data.List (genericLength)
 import Text.Blaze.Html5 (Html, (!))
-import Explorer.Web.Util (generateLink)
+import Scanner.Web.Util (generateLink)
 import qualified Text.Blaze.Html5.Attributes as A
 import qualified Text.Blaze.Html5 as H
 

--- a/src/Scanner/API/HealthCheck.hs
+++ b/src/Scanner/API/HealthCheck.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE MonoLocalBinds #-}
 
-module Explorer.API.HealthCheck(HealthCheckResult(..), healthCheck) where
+module Scanner.API.HealthCheck(HealthCheckResult(..), healthCheck) where
 
 import Data.Aeson (ToJSON)
 import GHC.Generics (Generic)
-import Explorer.Web.Util (SyncStatus(..))
-import Explorer.SharedContractCache (ContractListCacheStatusReader (..))
+import Scanner.Web.Util (SyncStatus(..))
+import Scanner.SharedContractCache (ContractListCacheStatusReader (..))
 
 data HealthCheckResult = HealthCheckResult
   { alive :: Bool

--- a/src/Scanner/API/IsContractOpen.hs
+++ b/src/Scanner/API/IsContractOpen.hs
@@ -1,4 +1,4 @@
-module Explorer.API.IsContractOpen(isContractOpen, isOpenAJAXBox) where
+module Scanner.API.IsContractOpen(isContractOpen, isOpenAJAXBox) where
  
 import Servant (throwError)
 import Opts (Options(..), mkUrlPrefix)
@@ -7,7 +7,7 @@ import Data.Maybe (isJust)
 import Text.Blaze.Html5 (Html, (!))
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
-import Explorer.Web.Util (generateLink)
+import Scanner.Web.Util (generateLink)
 
 isContractOpen :: Options -> Maybe [Char] -> IO Bool
 isContractOpen _ Nothing = throwError (userError "Need to specify contract id")

--- a/src/Scanner/Resources/Data.hs
+++ b/src/Scanner/Resources/Data.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
-module Explorer.Resources.Data(cssStylesheet, activeLight, greenStatus, inactiveLight, logo, magnifyingGlass, amberStatus, redStatus, downloadIcon, blockHeaderHashIcon, blockNoIcon, bookIcon, metadataIcon, roleTokenMintingPolicyIdIcon, slotNoIcon, statusIcon, versionIcon, prismCSS, prismJS, marlowePrismJS, marlowePrismCSS, stateIcon, arrowDropDown, alarmClock, circleIcon) where
+module Scanner.Resources.Data(cssStylesheet, activeLight, greenStatus, inactiveLight, logo, magnifyingGlass, amberStatus, redStatus, downloadIcon, blockHeaderHashIcon, blockNoIcon, bookIcon, metadataIcon, roleTokenMintingPolicyIdIcon, slotNoIcon, statusIcon, versionIcon, prismCSS, prismJS, marlowePrismJS, marlowePrismCSS, stateIcon, arrowDropDown, alarmClock, circleIcon) where
 
-import Explorer.Resources.Helpers (cssPath, embedResource, svgPath, prismPath)
+import Scanner.Resources.Helpers (cssPath, embedResource, svgPath, prismPath)
 import Data.ByteString (ByteString)
 
 ----------------

--- a/src/Scanner/Resources/Helpers.hs
+++ b/src/Scanner/Resources/Helpers.hs
@@ -1,4 +1,4 @@
-module Explorer.Resources.Helpers(cssPath, embedResource, svgPath, prismPath) where
+module Scanner.Resources.Helpers(cssPath, embedResource, svgPath, prismPath) where
 
 import Data.FileEmbed (embedFile, makeRelativeToProject, embedFile)
 import Language.Haskell.TH (Q)

--- a/src/Scanner/Resources/MimeTypes.hs
+++ b/src/Scanner/Resources/MimeTypes.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-module Explorer.Resources.MimeTypes(CSS, SVG, JS) where
+module Scanner.Resources.MimeTypes(CSS, SVG, JS) where
 
 import Network.HTTP.Media ((//), (/:), MediaType)
 import Servant (Accept (..), Proxy, MimeRender (..))

--- a/src/Scanner/SharedContractCache.hs
+++ b/src/Scanner/SharedContractCache.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
-module Explorer.SharedContractCache
+module Scanner.SharedContractCache
   ( ContractList(..)
   , ContractListCacheReader(..)
   , ContractListCacheStatusReader(..)
@@ -15,7 +15,7 @@ import Control.Concurrent.MVar ( MVar, modifyMVar_, newMVar, readMVar )
 import Data.Time (UTCTime)
 import Language.Marlowe.Runtime.Types.ContractsJSON (ContractListISeq)
 import Data.Time.Clock (getCurrentTime)
-import Explorer.Web.Util (SyncStatus, calculateSyncStatus)
+import Scanner.Web.Util (SyncStatus, calculateSyncStatus)
 import Language.Marlowe.Runtime.Types.IndexedSeq (empty)
 
 data InnerContractList = InnerContractList

--- a/src/Scanner/Web/ContractInfoDownload.hs
+++ b/src/Scanner/Web/ContractInfoDownload.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DataKinds #-}
-module Explorer.Web.ContractInfoDownload(contractDownloadInfo) where
+module Scanner.Web.ContractInfoDownload(contractDownloadInfo) where
 
 import Data.Aeson (encode)
 import Codec.Archive.Zip (toEntry, addEntryToArchive, emptyArchive, fromArchive)

--- a/src/Scanner/Web/ContractListView.hs
+++ b/src/Scanner/Web/ContractListView.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Explorer.Web.ContractListView
+module Scanner.Web.ContractListView
   (ContractListView(..), contractListView)
   where
 
@@ -11,8 +11,8 @@ import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes ( href, style, class_ )
 import Text.Printf ( printf )
 
-import Explorer.SharedContractCache ( ContractListCacheReader, readContractList, ContractList(..) )
-import Explorer.Web.Util ( baseDoc, generateLink, formatTimeDiff, makeLocalDateTime, tableList, tlhr, tlh, tlr, tld, SyncStatus (..), tldhc, makeTitleDiv )
+import Scanner.SharedContractCache ( ContractListCacheReader, readContractList, ContractList(..) )
+import Scanner.Web.Util ( baseDoc, generateLink, formatTimeDiff, makeLocalDateTime, tableList, tlhr, tlh, tlr, tld, SyncStatus (..), tldhc, makeTitleDiv )
 import Language.Marlowe.Runtime.Types.ContractsJSON ( ContractInList (..), ContractLinks (..), Resource(..), ContractInList (..), ContractListISeq )
 
 import Data.Foldable (toList)
@@ -20,11 +20,11 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
 import qualified Language.Marlowe.Runtime.Types.IndexedSeq as ISeq
 import qualified Language.Marlowe.Runtime.Types.ContractsJSON as CSJ
-import Explorer.API.IsContractOpen (isOpenAJAXBox)
-import Explorer.API.GetNumTransactions (numTransactionsAJAXBox)
+import Scanner.API.IsContractOpen (isOpenAJAXBox)
+import Scanner.API.GetNumTransactions (numTransactionsAJAXBox)
 import Opts (Options (..), TitleLabel (TitleLabel))
 import Data.List.Extra (trim)
-import Explorer.Web.Pagination (PageInfo (..), renderNavBar, bindVal, calculateRange, PageLinkGenerator, calcLastPage)
+import Scanner.Web.Pagination (PageInfo (..), renderNavBar, bindVal, calculateRange, PageLinkGenerator, calcLastPage)
 
 data CLVR = CLVR {
       -- | Info about current page
@@ -163,7 +163,7 @@ renderCIRs (ContractListView { titleLabel = labelForTitle
 
 renderCIRs (ContractListView { titleLabel = labelForTitle
                              , clvContents = ContractListViewStillSyncing}) =
-  baseDoc Syncing headerText (makeTitleDiv headerText) $ string "The explorer is still synchronising with the chain. Please, try again later"
+  baseDoc Syncing headerText (makeTitleDiv headerText) $ string "MarloweScan is still synchronising with the chain. Please, try again later"
     where headerText = "Marlowe Contract List" `appIfNotBlank` labelForTitle
 
 renderCIRs (ContractListView { clvContents = ContractListViewError curSyncStatus msg }) =

--- a/src/Scanner/Web/ContractView.hs
+++ b/src/Scanner/Web/ContractView.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE MonoLocalBinds #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
-module Explorer.Web.ContractView
+module Scanner.Web.ContractView
   (ContractView(..), contractView)
   where
 
@@ -18,7 +18,7 @@ import Text.Blaze.Html5 (Html, Markup, ToMarkup(toMarkup), (!), a, b, code, p, s
 import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes (href, style, class_)
 import Text.Printf (printf)
-import Explorer.Web.Util (tr, baseDoc, stringToHtml, prettyPrintAmount, makeLocalDateTime, generateLink,
+import Scanner.Web.Util (tr, baseDoc, stringToHtml, prettyPrintAmount, makeLocalDateTime, generateLink,
                           mkTransactionExplorerLink, mkBlockExplorerLink, mkTokenPolicyExplorerLink,
                           valueToString, SyncStatus, downloadIcon, bookIcon, blockHeaderHashIcon,
                           roleTokenMintingPolicyIdIcon, slotNoIcon, blockNoIcon, metadataIcon, versionIcon,
@@ -37,9 +37,9 @@ import Prelude hiding (div)
 import Data.Time (UTCTime)
 import qualified Data.Text as T
 import qualified Data.Map as M
-import Explorer.SharedContractCache (ContractListCacheStatusReader(getSyncStatus))
+import Scanner.SharedContractCache (ContractListCacheStatusReader(getSyncStatus))
 import Data.Maybe (isJust, catMaybes, fromMaybe)
-import Explorer.Web.Pagination (bindVal, calcLastPage, calculateRange, PageInfo (..), PageLinkGenerator, renderNavBar)
+import Scanner.Web.Pagination (bindVal, calcLastPage, calculateRange, PageInfo (..), PageLinkGenerator, renderNavBar)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Base16 as BS16
 
@@ -468,8 +468,8 @@ renderCTLVRTDetail cid blockExplHost (CTLVRTDetail { txPrev = txPrev'
                                                    }) = do
   H.div ! class_ "pagination-box"
         $ do p $ string ""
-             maybe (H.div $ previousTransactionLabel False) (explorerTransactionLinkFromRuntimeLink previousTransactionLabel) txPrev'
-             maybe (H.div $ nextTransactionLabel False) (explorerTransactionLinkFromRuntimeLink nextTransactionLabel) txNext'
+             maybe (H.div $ previousTransactionLabel False) (marloweScanTransactionLinkFromRuntimeLink previousTransactionLabel) txPrev'
+             maybe (H.div $ nextTransactionLabel False) (marloweScanTransactionLinkFromRuntimeLink nextTransactionLabel) txNext'
              p $ string ""
   dtable $ do
     tr $ do
@@ -521,7 +521,7 @@ renderCTLVRTDetail cid blockExplHost (CTLVRTDetail { txPrev = txPrev'
   where previousTransactionLabel enabled = makeTransactionLabel enabled "Previous Transaction"
         nextTransactionLabel enabled = makeTransactionLabel enabled "Next Transaction"
         makeTransactionLabel enabled = H.div ! class_ (if enabled then "page-button" else "page-button page-button-disabled")
-        explorerTransactionLinkFromRuntimeLink linkContent rtTxLink =
+        marloweScanTransactionLinkFromRuntimeLink linkContent rtTxLink =
           case split '/' rtTxLink of
             [_, _, _, tTransactionId] -> invisibleLinkToTransaction cid tTransactionId $ linkContent True
             _ -> H.div $ linkContent False

--- a/src/Scanner/Web/Pagination.hs
+++ b/src/Scanner/Web/Pagination.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Explorer.Web.Pagination (PageInfo(..), PageLinkGenerator, bindVal, calcLastPage, calculateRange, renderNavBar) where
+module Scanner.Web.Pagination (PageInfo(..), PageLinkGenerator, bindVal, calcLastPage, calculateRange, renderNavBar) where
 
 import qualified Text.Blaze.Html5 as H
 import Text.Blaze.Html5.Attributes (class_)

--- a/src/Scanner/Web/PrettyHtml.hs
+++ b/src/Scanner/Web/PrettyHtml.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Explorer.Web.PrettyHtml(PrettyHtml) where
+module Scanner.Web.PrettyHtml(PrettyHtml) where
 import Servant (Accept (..), MimeRender (..), Proxy)
 import Text.Blaze (ToMarkup)
 import Text.Blaze.Html (toHtml, Html)

--- a/src/Scanner/Web/Util.hs
+++ b/src/Scanner/Web/Util.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Explorer.Web.Util (PopupLevel(..), SyncStatus(..), baseDoc, formatTimeDiff, generateLink, linkFor,
+module Scanner.Web.Util (PopupLevel(..), SyncStatus(..), baseDoc, formatTimeDiff, generateLink, linkFor,
                           makeLocalDateTime, prettyPrintAmount, stringToHtml, table, td, th, tr,
                           mkTransactionExplorerLink, mkBlockExplorerLink, mkTokenPolicyExplorerLink,
                           valueToString, tableList, tlh, tlhr, tlr, tld, calculateSyncStatus, tldhc,


### PR DESCRIPTION
This PR renames marlowe-explorer to marlowe-scan, renames the Explorer package to Scanner, and adapts a few parameters and documentation that referred to the project as Marlowe Explorer to refer to it as MarloweScan