### PR TITLE
Fix GHC package in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc928", doBenchmark ? false }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc92", doBenchmark ? false }:
 
 let
   pkgs = nixpkgs;


### PR DESCRIPTION
Turns out the package is actually called `ghc92` and not `ghc928`