### PR TITLE
Create nix flake to ensure reproducibility

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a
       with:
         nix_path: nixpkgs=channel:nixos-23.05
-    - run: nix-build shell.nix
-    - run: nix-shell --run "hlint src && fix-hie && git diff --exit-code hie.yaml"
+    - run: nix build
+    - run: nix develop --command bash -c "hlint src && gen-hie --stack > hie.yaml && git diff --exit-code hie.yaml"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,6 +14,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - uses: freckle/stack-cache-action@ed5f0b5ad23c22386472fc61b0b8da7fd6bfbc67
-      - uses: freckle/stack-action@d32c32d930606e981e7bb34c624c31b5c5f9bdc6
-    
+      - uses: freckle/stack-action@178359c42adbc961a7531d956f55e12b360f38af
+

--- a/README.md
+++ b/README.md
@@ -8,31 +8,37 @@ This version of MarloweScan requires a running instance of the Marlowe Runtime. 
 
 ## Using Nix
 
-This repo provides a `shell.nix` file that can be used for developing and building MarloweScan without having to worry about dependencies.
+This repo provides a `flake.nix` file that can be used for developing and building MarloweScan without having to worry about dependencies.
 
 ### Building with Nix
 
-To build MarloweScan with Nix, you can use the `nix-build` command with `shell.nix`:
+To build MarloweScan with Nix, you can use the `nix` command:
 
 ```bash
-nix-build shell.nix
+nix build
 ```
 
 The resulting executable will be made available in `result/bin/marlowe-scan-exe`
 
-### Development shell
-
-As usual, you can use the `nix-shell` command to enter the development environment from the root folder of the project:
+Alternatively, you can run MarloweScan directly by writing:
 
 ```bash
-nix-shell
+nix run
 ```
 
-That will make the required Haskell libraries, tools like cabal, stack, the Haskell Language Server, and the `gen-hie` command available in the command line.
+### Development shell
+
+As usual, you can use the `nix` command to enter the development environment from the root folder of the project:
+
+```bash
+nix develop
+```
+
+That will make the required Haskell libraries, tools like cabal, stack, the Haskell Language Server, and the `fix-hie` command available in the command line.
 
 ### Caching dependencies
 
-In order to take advantage of caching, you can use the `https://nixos.org/channels/nixos-22.11` channel. If using a different channel like `unstable`, building may take a while.
+In order to take advantage of caching, you can use the `https://nixos.org/channels/nixos-23.05` channel.
 
 ## Using Stack
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,11 @@
     defaultPackage.x86_64-linux =
       with import nixpkgs { system = "x86_64-linux"; };
       with haskellPackages;
-      import ./shell.nix { nixpkgs = nixpkgs; haskellPackages = haskellPackages; };
+      import ./shell.nix { nixpkgs = nixpkgs; haskellPackages = haskellPackages; tools = [ cabal-install stack ];};
     devShells.x86_64-linux.default =
       with import nixpkgs { system = "x86_64-linux"; };
       with haskellPackages;
-      (import ./shell.nix { nixpkgs = nixpkgs; haskellPackages = haskellPackages; }).env;
+      (import ./shell.nix { nixpkgs = nixpkgs; haskellPackages = haskellPackages; tools = [ cabal-install stack ];}).env;
  };
 
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "MarloweScan - An explorer for Marlowe contracts";
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/23.05;
+
+  outputs = { self, nixpkgs }: {
+    defaultPackage.x86_64-linux =
+      with import nixpkgs { system = "x86_64-linux"; };
+      with haskellPackages;
+      import ./shell.nix { nixpkgs = nixpkgs; haskellPackages = haskellPackages; };
+    devShells.x86_64-linux.default =
+      with import nixpkgs { system = "x86_64-linux"; };
+      with haskellPackages;
+      (import ./shell.nix { nixpkgs = nixpkgs; haskellPackages = haskellPackages; }).env;
+ };
+
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc92", doBenchmark ? false }:
+{ nixpkgs ? import <nixpkgs> {}, haskellPackages ? (import <nixpkgs> {}).haskellPackages }:
 
 let
   pkgs = nixpkgs;
@@ -29,14 +29,5 @@ let
           }
         '';
       };
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
-
-  drv = variant (haskellPackages.callPackage f {});
-
-in
-
-  if pkgs.lib.inNixShell then drv.env else drv
+  d = haskellPackages.callPackage f {};
+in d // { meta = d.meta // { mainProgram= "marlowe-scan-exe"; }; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,13 @@
-{ nixpkgs ? import <nixpkgs> {}, haskellPackages ? (import <nixpkgs> {}).haskellPackages }:
+{ nixpkgs ? import <nixpkgs> {}, haskellPackages ? nixpkgs.haskellPackages, tools ? [ ] }:
 
 let
   pkgs = nixpkgs;
-  f = { mkDerivation, base, blaze-html, gtk, lib, process
-      , temporary, zlib, aeson, servant-server, wai, warp, haskell-language-server
-      , hspec, hspec-wai, servant-blaze, http-client, wl-pprint
-      , http-conduit, http-types, errors, zip-archive
+  f = { mkDerivation, base, aeson, aeson-pretty, base16-bytestring, blaze-html,
+          blaze-markup, bytestring, containers, errors, extra,
+          file-embed, ghc, http-client, http-conduit, http-media,
+          http-types, scientific, servant-blaze, servant-server,
+          template-haskell, text, utf8-string, wai, warp, wl-pprint,
+          zip-archive, zlib, haskell-language-server, lib, hspec, hspec-wai
       }:
       mkDerivation {
         pname = "marlowe-scan";
@@ -14,13 +16,13 @@ let
         isLibrary = false;
         isExecutable = true;
         executableHaskellDepends = [
-          base blaze-html gtk process temporary zlib
-          aeson servant-server wai warp
-          haskell-language-server errors
-          hspec hspec-wai servant-blaze
-          http-client wl-pprint http-conduit http-types
-          zip-archive
-        ];
+          base aeson aeson-pretty base16-bytestring blaze-html
+          blaze-markup bytestring containers errors extra
+          file-embed ghc http-client http-conduit http-media
+          http-types scientific servant-blaze servant-server
+          template-haskell text utf8-string wai warp wl-pprint
+          zip-archive zlib haskell-language-server hspec hspec-wai
+        ] ++ tools;
         license = "unknown";
         hydraPlatforms = lib.platforms.none;
         shellHook = ''

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.25
+resolver: lts-20.14
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This PR wraps the nix scripts in a flake so that their build are easy to reproduce.

I've tested that `nix build`  and `nix develop` work the way `nix-shell` and `nix-build` worked before, and that `nix run` works.

Also updated the `README.md`